### PR TITLE
Setting up database tables and seed data

### DIFF
--- a/backend/internal/supabase/migrations/20240917002108_base_schema.sql
+++ b/backend/internal/supabase/migrations/20240917002108_base_schema.sql
@@ -1,0 +1,64 @@
+create table if not exists "user" (
+    id uuid primary key default uuid_generate_v4(),
+    username text not null,
+    display_name text not null,
+    bio text,
+    profile_picture text,
+    linked_account text,
+    created_at timestamp with time zone default now(),
+    updated_at timestamp with time zone default now()
+);
+
+create table if not exists artist (
+    id uuid primary key default uuid_generate_v4(),
+    name text not null,
+    photo text,
+    bio text
+);
+
+create table if not exists genre (
+    id uuid primary key default uuid_generate_v4(),
+    name text not null
+);
+
+create table if not exists album (
+    id uuid primary key default uuid_generate_v4(),
+    title text not null,
+    release_date date not null,
+    cover text,
+    country text,
+    genre_id uuid references genre(id)
+);
+
+create table if not exists album_artist (
+    album_id uuid references album(id),
+    artist_id uuid references artist(id),
+    primary key (album_id, artist_id)
+);
+
+create table if not exists track (
+    id uuid primary key default uuid_generate_v4(),
+    album_id uuid references album(id),
+    artist_id uuid references artist(id),
+    title text not null,
+    duration_seconds int not null
+);
+
+create table if not exists track_artist (
+    track_id uuid references track(id),
+    artist_id uuid references artist(id),
+    primary key (track_id, artist_id)
+);
+
+create type media_type as enum ('album', 'track');
+
+create table if not exists review (
+    id uuid primary key default uuid_generate_v4(),
+    user_id uuid not null references "user"(id),
+    media_id uuid not null, -- can't foreign key to album or track because it could be either
+    media_type media_type not null,
+    rating int not null,
+    comment text,
+    created_at timestamp with time zone default now(),
+    updated_at timestamp with time zone default now()
+);

--- a/backend/internal/supabase/migrations/20240917002108_base_schema.sql
+++ b/backend/internal/supabase/migrations/20240917002108_base_schema.sql
@@ -10,52 +10,51 @@ create table if not exists "user" (
 );
 
 create table if not exists artist (
-    id uuid primary key default uuid_generate_v4(),
+    id bigserial primary key,
     name text not null,
     photo text,
     bio text
 );
 
 create table if not exists genre (
-    id uuid primary key default uuid_generate_v4(),
+    id serial primary key,
     name text not null
 );
 
 create table if not exists album (
-    id uuid primary key default uuid_generate_v4(),
+    id bigserial primary key,
     title text not null,
     release_date date not null,
     cover text,
     country text,
-    genre_id uuid references genre(id)
+    genre_id integer references genre(id)
 );
 
 create table if not exists album_artist (
-    album_id uuid references album(id),
-    artist_id uuid references artist(id),
+    album_id bigint references album(id),
+    artist_id bigint references artist(id),
     primary key (album_id, artist_id)
 );
 
 create table if not exists track (
-    id uuid primary key default uuid_generate_v4(),
-    album_id uuid references album(id),
-    artist_id uuid references artist(id),
+    id bigserial primary key,
+    album_id bigint not null references album(id),
     title text not null,
     duration_seconds int not null
 );
 
 create table if not exists track_artist (
-    track_id uuid references track(id),
-    artist_id uuid references artist(id),
+    track_id bigint not null references track(id),
+    artist_id bigint not null references artist(id),
     primary key (track_id, artist_id)
 );
 
 create type media_type as enum ('album', 'track');
 
 create table if not exists review (
-    id uuid primary key default uuid_generate_v4(),
+    id serial primary key,
     user_id uuid not null references "user"(id),
-    media_id uuid not null, -- can't foreign key to album or track because it could be either
+    media_id integer not null, -- can't foreign key to album or track because it could be either
     media_type media_type not null,
     rating int not null,
     comment text,

--- a/backend/internal/supabase/migrations/20240917002108_base_schema.sql
+++ b/backend/internal/supabase/migrations/20240917002108_base_schema.sql
@@ -1,6 +1,6 @@
 create table if not exists "user" (
     id uuid primary key default uuid_generate_v4(),
-    username text not null,
+    username text not null unique,
     display_name text not null,
     bio text,
     profile_picture text,

--- a/backend/internal/supabase/seed.sql
+++ b/backend/internal/supabase/seed.sql
@@ -2,6 +2,54 @@ INSERT INTO users (user_id, first_name, last_name, email, phone, profile_picture
 VALUES
   ('user1', 'John', 'Smith', 'john.smith@example.com', '123-456-7890', NULL),
   ('user2', 'Jane', 'Doe', 'jane.doe@example.com', '987-654-3210', NULL),
-  ('user3', 'Bob', 'Johnson', 'bob.johnson@example.com', NULL, NULL, NULL),
-  ('user4', 'Emily', 'Garcia', 'emily.garcia@example.com', '555-1212', NULL)
-;
+  ('user3', 'Bob', 'Johnson', 'bob.johnson@example.com', NULL, NULL),
+  ('user4', 'Emily', 'Garcia', 'emily.garcia@example.com', '555-1212', NULL);
+
+INSERT INTO "user" (id, username, display_name, bio, profile_picture, linked_account, created_at, updated_at)
+VALUES
+  ('1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'john_doe', 'John Doe', 'Software developer from New York.', 'https://example.com/profiles/john_doe.jpg', 'john_doe_linked', now(), now()),
+  ('2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e', 'jane_smith', 'Jane Smith', 'Graphic designer from California.', 'https://example.com/profiles/jane_smith.jpg', 'jane_smith_linked', now(), now()),
+  ('3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f', 'alice_jones', 'Alice Jones', 'Content writer from Texas.', 'https://example.com/profiles/alice_jones.jpg', 'alice_jones_linked', now(), now()),
+  ('4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a', 'bob_brown', 'Bob Brown', 'Digital marketer from Florida.', 'https://example.com/profiles/bob_brown.jpg', 'bob_brown_linked', now(), now()),
+  ('5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9c0d', 'charlie_davis', 'Charlie Davis', 'SEO specialist from Washington.', 'https://example.com/profiles/charlie_davis.jpg', 'charlie_davis_linked', now(), now());
+
+INSERT INTO artist (id, name, photo, bio)
+VALUES
+  ('3d6f0b8e-1c4b-4b8e-8f8e-1c4b4b8e8f8e', 'The Beatles', 'https://upload.wikimedia.org/wikipedia/commons/1/1d/The_Fabs.JPG', 'The Beatles were an English rock band formed in Liverpool in 1960. With a line-up comprising John Lennon, Paul McCartney, George Harrison and Ringo Starr, they are regarded as the most influential band of all time.'),
+  ('4e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d', 'The Rolling Stones', 'https://upload.wikimedia.org/wikipedia/commons/2/2c/RollingStones-01.jpg', 'The Rolling Stones are an English rock band formed in London in 1962. The first stable line-up consisted of bandleader Brian Jones (guitar, harmonica, keyboards), Mick Jagger (lead vocals, harmonica), Keith Richards (guitar, vocals), Bill Wyman (bass guitar), Charlie Watts (drums), and Ian Stewart (piano).');
+
+INSERT INTO genre (id, name)
+VALUES
+  ('0e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d', 'Rock'),
+  ('1f8e2d6e-3e6d-6d9e-af9e-3e6d6d9eaf9e', 'Pop');
+
+INSERT INTO album (id, title, release_date, cover, country, genre_id)
+VALUES
+  ('5f9e3d7e-4f7e-7e9e-bf9e-4f7e7e9ebf9e', 'Abbey Road', '1969-09-26', 'https://upload.wikimedia.org/wikipedia/en/4/42/Beatles_-_Abbey_Road.jpg', 'United Kingdom', '0e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d'),
+  ('6f0e4d8e-5f8e-8e9e-cf9e-5f8e8e9ecf9e', 'Sticky Fingers', '1971-04-23', 'https://upload.wikimedia.org/wikipedia/en/3/38/Stickyfingersalbumcover.jpg', 'United Kingdom', '0e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d');
+
+INSERT INTO album_artist (album_id, artist_id)
+VALUES
+  ('5f9e3d7e-4f7e-7e9e-bf9e-4f7e7e9ebf9e', '3d6f0b8e-1c4b-4b8e-8f8e-1c4b4b8e8f8e'),
+  ('6f0e4d8e-5f8e-8e9e-cf9e-5f8e8e9ecf9e', '4e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d');
+
+INSERT INTO track (id, album_id, artist_id, title, duration_seconds)
+VALUES
+  ('7f1e5d9e-6f9e-9e9e-df9e-6f9e9e9edf9e', '5f9e3d7e-4f7e-7e9e-bf9e-4f7e7e9ebf9e', '3d6f0b8e-1c4b-4b8e-8f8e-1c4b4b8e8f8e', 'Come Together', 248),
+  ('8f2e6d0e-7f0e-0e9e-ef9e-7f0e0e9eef9e', '5f9e3d7e-4f7e-7e9e-bf9e-4f7e7e9ebf9e', '3d6f0b8e-1c4b-4b8e-8f8e-1c4b4b8e8f8e', 'Something', 182),
+  ('9f3e7d1e-8f1e-1e9e-ff9e-8f1e1e9eff9e', '6f0e4d8e-5f8e-8e9e-cf9e-5f8e8e9ecf9e', '4e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d', 'Brown Sugar', 212),
+  ('af4e8d2e-9f2e-2e9e-0f9e-9f2e2e9e0f9e', '6f0e4d8e-5f8e-8e9e-cf9e-5f8e8e9ecf9e', '4e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d', 'Wild Horses', 342);
+
+INSERT INTO track_artist (track_id, artist_id)
+VALUES
+  ('7f1e5d9e-6f9e-9e9e-df9e-6f9e9e9edf9e', '3d6f0b8e-1c4b-4b8e-8f8e-1c4b4b8e8f8e'),
+  ('8f2e6d0e-7f0e-0e9e-ef9e-7f0e0e9eef9e', '3d6f0b8e-1c4b-4b8e-8f8e-1c4b4b8e8f8e'),
+  ('9f3e7d1e-8f1e-1e9e-ff9e-8f1e1e9eff9e', '4e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d'),
+  ('af4e8d2e-9f2e-2e9e-0f9e-9f2e2e9e0f9e', '4e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d');
+
+INSERT INTO review (id, user_id, media_id, media_type, rating, comment)
+VALUES
+  ('bf5e9d3e-af3e-3e9e-1f9e-af3e3e9e1f9e', '1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', '5f9e3d7e-4f7e-7e9e-bf9e-4f7e7e9ebf9e', 'album', 5, 'This is a great album!'),
+  ('df7e1d5e-cf5e-5e9e-3f9e-cf5e5e9e3f9e', '2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e', '6f0e4d8e-5f8e-8e9e-cf9e-5f8e8e9ecf9e', 'album', 4, 'I like this album.'),
+  ('ff9e3d7e-ef7e-7e9e-5f9e-ef7e7e9e5f9e', '3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f', '7f1e5d9e-6f9e-9e9e-df9e-6f9e9e9edf9e', 'track', 3, 'This song is okay.'),
+  ('1f1e5d9e-1f9e-9e9e-7f9e-1f9e9e9e7f9e', '4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a', '9f3e7d1e-8f1e-1e9e-ff9e-8f1e1e9eff9e', 'track', 2, 'I don''t like this song.');

--- a/backend/internal/supabase/seed.sql
+++ b/backend/internal/supabase/seed.sql
@@ -1,55 +1,55 @@
-INSERT INTO users (user_id, first_name, last_name, email, phone, profile_picture)
-VALUES
-  ('user1', 'John', 'Smith', 'john.smith@example.com', '123-456-7890', NULL),
-  ('user2', 'Jane', 'Doe', 'jane.doe@example.com', '987-654-3210', NULL),
-  ('user3', 'Bob', 'Johnson', 'bob.johnson@example.com', NULL, NULL),
-  ('user4', 'Emily', 'Garcia', 'emily.garcia@example.com', '555-1212', NULL);
-
 INSERT INTO "user" (id, username, display_name, bio, profile_picture, linked_account, created_at, updated_at)
 VALUES
   ('1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'john_doe', 'John Doe', 'Software developer from New York.', 'https://example.com/profiles/john_doe.jpg', 'john_doe_linked', now(), now()),
   ('2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e', 'jane_smith', 'Jane Smith', 'Graphic designer from California.', 'https://example.com/profiles/jane_smith.jpg', 'jane_smith_linked', now(), now()),
   ('3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f', 'alice_jones', 'Alice Jones', 'Content writer from Texas.', 'https://example.com/profiles/alice_jones.jpg', 'alice_jones_linked', now(), now()),
-  ('4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a', 'bob_brown', 'Bob Brown', 'Digital marketer from Florida.', 'https://example.com/profiles/bob_brown.jpg', 'bob_brown_linked', now(), now()),
-  ('5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9c0d', 'charlie_davis', 'Charlie Davis', 'SEO specialist from Washington.', 'https://example.com/profiles/charlie_davis.jpg', 'charlie_davis_linked', now(), now());
+  ('4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9d', 'bob_brown', 'Bob Brown', 'Digital marketer from Florida.', 'https://example.com/profiles/bob_brown.jpg', 'bob_brown_linked', now(), now()),
+  ('5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9d0e', 'charlie_davis', 'Charlie Davis', 'SEO specialist from Washington.', 'https://example.com/profiles/charlie_davis.jpg', 'charlie_davis_linked', now(), now());
 
-INSERT INTO artist (id, name, photo, bio)
+INSERT INTO artist (name, photo, bio)
 VALUES
-  ('3d6f0b8e-1c4b-4b8e-8f8e-1c4b4b8e8f8e', 'The Beatles', 'https://upload.wikimedia.org/wikipedia/commons/1/1d/The_Fabs.JPG', 'The Beatles were an English rock band formed in Liverpool in 1960. With a line-up comprising John Lennon, Paul McCartney, George Harrison and Ringo Starr, they are regarded as the most influential band of all time.'),
-  ('4e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d', 'The Rolling Stones', 'https://upload.wikimedia.org/wikipedia/commons/2/2c/RollingStones-01.jpg', 'The Rolling Stones are an English rock band formed in London in 1962. The first stable line-up consisted of bandleader Brian Jones (guitar, harmonica, keyboards), Mick Jagger (lead vocals, harmonica), Keith Richards (guitar, vocals), Bill Wyman (bass guitar), Charlie Watts (drums), and Ian Stewart (piano).');
+  ('The Beatles', 'https://upload.wikimedia.org/wikipedia/commons/1/1d/The_Fabs.JPG', 'The Beatles were an English rock band formed in Liverpool in 1960. With a line-up comprising John Lennon, Paul McCartney, George Harrison and Ringo Starr, they are regarded as the most influential band of all time.'),
+  ('The Rolling Stones', 'https://upload.wikimedia.org/wikipedia/commons/2/2c/RollingStones-01.jpg', 'The Rolling Stones are an English rock band formed in London in 1962. The first stable line-up consisted of bandleader Brian Jones (guitar, harmonica, keyboards), Mick Jagger (lead vocals, harmonica), Keith Richards (guitar, vocals), Bill Wyman (bass guitar), Charlie Watts (drums), and Ian Stewart (piano).'),
+  ('Taylor Swift', 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d7/Taylor_Swift_at_the_2023_MTV_Video_Music_Awards_4.png/220px-Taylor_Swift_at_the_2023_MTV_Video_Music_Awards_4.png', 'Taylor Alison Swift is an American singer-songwriter. Known for her autobiographical songwriting, artistic reinventions, and cultural impact, Swift is a leading figure in popular music and the subject of widespread public interest.');
 
-INSERT INTO genre (id, name)
+INSERT INTO genre (name)
 VALUES
-  ('0e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d', 'Rock'),
-  ('1f8e2d6e-3e6d-6d9e-af9e-3e6d6d9eaf9e', 'Pop');
+  ('Rock'),
+  ('Pop');
 
-INSERT INTO album (id, title, release_date, cover, country, genre_id)
+INSERT INTO album (title, release_date, cover, country, genre_id)
 VALUES
-  ('5f9e3d7e-4f7e-7e9e-bf9e-4f7e7e9ebf9e', 'Abbey Road', '1969-09-26', 'https://upload.wikimedia.org/wikipedia/en/4/42/Beatles_-_Abbey_Road.jpg', 'United Kingdom', '0e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d'),
-  ('6f0e4d8e-5f8e-8e9e-cf9e-5f8e8e9ecf9e', 'Sticky Fingers', '1971-04-23', 'https://upload.wikimedia.org/wikipedia/en/3/38/Stickyfingersalbumcover.jpg', 'United Kingdom', '0e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d');
+  ('Abbey Road', '1969-09-26', 'https://upload.wikimedia.org/wikipedia/en/4/42/Beatles_-_Abbey_Road.jpg', 'United Kingdom', 1),
+  ('Sticky Fingers', '1971-04-23', 'https://upload.wikimedia.org/wikipedia/en/3/38/Stickyfingersalbumcover.jpg', 'United Kingdom', 1),
+  ('1989 (Taylor''s Version)', '2023-10-27', 'https://upload.wikimedia.org/wikipedia/en/thumb/d/d5/Taylor_Swift_-_1989_%28Taylor%27s_Version%29.png/220px-Taylor_Swift_-_1989_%28Taylor%27s_Version%29.png', 'United States', 2);
 
 INSERT INTO album_artist (album_id, artist_id)
 VALUES
-  ('5f9e3d7e-4f7e-7e9e-bf9e-4f7e7e9ebf9e', '3d6f0b8e-1c4b-4b8e-8f8e-1c4b4b8e8f8e'),
-  ('6f0e4d8e-5f8e-8e9e-cf9e-5f8e8e9ecf9e', '4e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d');
+  (1, 1),
+  (2, 2),
+  (3, 3);
 
-INSERT INTO track (id, album_id, artist_id, title, duration_seconds)
+INSERT INTO track (album_id, title, duration_seconds)
 VALUES
-  ('7f1e5d9e-6f9e-9e9e-df9e-6f9e9e9edf9e', '5f9e3d7e-4f7e-7e9e-bf9e-4f7e7e9ebf9e', '3d6f0b8e-1c4b-4b8e-8f8e-1c4b4b8e8f8e', 'Come Together', 248),
-  ('8f2e6d0e-7f0e-0e9e-ef9e-7f0e0e9eef9e', '5f9e3d7e-4f7e-7e9e-bf9e-4f7e7e9ebf9e', '3d6f0b8e-1c4b-4b8e-8f8e-1c4b4b8e8f8e', 'Something', 182),
-  ('9f3e7d1e-8f1e-1e9e-ff9e-8f1e1e9eff9e', '6f0e4d8e-5f8e-8e9e-cf9e-5f8e8e9ecf9e', '4e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d', 'Brown Sugar', 212),
-  ('af4e8d2e-9f2e-2e9e-0f9e-9f2e2e9e0f9e', '6f0e4d8e-5f8e-8e9e-cf9e-5f8e8e9ecf9e', '4e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d', 'Wild Horses', 342);
+  (1, 'Come Together', 248),
+  (1, 'Something', 182),
+  (2, 'Brown Sugar', 212),
+  (2, 'Wild Horses', 342),
+  (3, 'Wonderland (Taylor''s Version)', 365);
+
 
 INSERT INTO track_artist (track_id, artist_id)
 VALUES
-  ('7f1e5d9e-6f9e-9e9e-df9e-6f9e9e9edf9e', '3d6f0b8e-1c4b-4b8e-8f8e-1c4b4b8e8f8e'),
-  ('8f2e6d0e-7f0e-0e9e-ef9e-7f0e0e9eef9e', '3d6f0b8e-1c4b-4b8e-8f8e-1c4b4b8e8f8e'),
-  ('9f3e7d1e-8f1e-1e9e-ff9e-8f1e1e9eff9e', '4e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d'),
-  ('af4e8d2e-9f2e-2e9e-0f9e-9f2e2e9e0f9e', '4e7f1c9d-2d5c-5c9d-9f9d-2d5c5c9d9f9d');
+  (1, 1),
+  (2, 1),
+  (3, 2),
+  (4, 2),
+  (5, 3);
 
-INSERT INTO review (id, user_id, media_id, media_type, rating, comment)
+INSERT INTO review (user_id, media_id, media_type, rating, comment)
 VALUES
-  ('bf5e9d3e-af3e-3e9e-1f9e-af3e3e9e1f9e', '1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', '5f9e3d7e-4f7e-7e9e-bf9e-4f7e7e9ebf9e', 'album', 5, 'This is a great album!'),
-  ('df7e1d5e-cf5e-5e9e-3f9e-cf5e5e9e3f9e', '2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e', '6f0e4d8e-5f8e-8e9e-cf9e-5f8e8e9ecf9e', 'album', 4, 'I like this album.'),
-  ('ff9e3d7e-ef7e-7e9e-5f9e-ef7e7e9e5f9e', '3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f', '7f1e5d9e-6f9e-9e9e-df9e-6f9e9e9edf9e', 'track', 3, 'This song is okay.'),
-  ('1f1e5d9e-1f9e-9e9e-7f9e-1f9e9e9e7f9e', '4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a', '9f3e7d1e-8f1e-1e9e-ff9e-8f1e1e9eff9e', 'track', 2, 'I don''t like this song.');
+  ('1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 1, 'album', 5, 'This is a great album!'),
+  ('2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e', 2, 'album', 4, 'I like this album.'),
+  ('3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f', 1, 'track', 3, 'This song is okay.'),
+  ('4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9d', 3, 'track', 2, 'I don''t like this song.'),
+  ('4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9d', 5, 'track', 2, 'This song is the best song ever');


### PR DESCRIPTION
This PR adds a migration script and seed data for several of the tables we discussed within our schema.

Tables: `user`, `artist`, `genre`, `album`, `album_artist`, `track`, `track_artist`, `review`

Some notes on design decisions:
* `album_artist` was created to handle the case of albums with multiple artists ([case in point](https://open.spotify.com/album/2if1gb3t6IkhiKzrtS9Glc?si=W-IEPTZ4TiibJnKvpkNEXA)). since it's a many to many relationship, we thought a bridge table best represented this concept, and we want to make sure to account for these albums since they're rarer and more likely to be discussed in the music community.
* `track_artist` was created with the same idea in mind - tracks can have multiple artists, and artists can have multiple tracks, leading us to use a bridge table.
* After reading [this article on primary key recommendations](https://supabase.com/blog/choosing-a-postgres-primary-key), I decided to go with serial (auto-incrementing) bigint values for most tables rather than uuids because uuids feel like overkill and need unnecessary extra storage and indexing time for our non-sensitive music/review data. For users, however, I kept uuids for the sake of added security and non-guessability

Tested using local Supabase migration, which successfully ran migration script and populated data for each table which is viewable in the local Supabase dashboard
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/83f3ff9f-eb9a-4988-9370-cab12a6c9c36">

Table relations shown here:
<img width="869" alt="image" src="https://github.com/user-attachments/assets/5f982d06-acdb-4bc4-a31f-fda5ddcb842c">


**Comments, questions, and suggestions welcome!! Anticipating and addressing schema issues is going to be way easier now than in the future once we've started implementing things :)**