### PR TITLE
fix: return updated at and created at from db on insert review

### DIFF
--- a/backend/internal/storage/postgres/schema/review.go
+++ b/backend/internal/storage/postgres/schema/review.go
@@ -35,10 +35,10 @@ func (r *ReviewRepository) CreateReview(ctx context.Context, review *models.Revi
 	INSERT INTO review (user_id, media_id, media_type, rating, comment)
 	SELECT $1, $2, $3::media_type, $4, $5
 	FROM media_check
-	RETURNING id;
+	RETURNING id, created_at, updated_at;
 	`
 
-	if err := r.QueryRow(ctx, query, review.UserID, review.MediaID, review.MediaType, review.Rating, review.Comment).Scan(&review.ID); err != nil {
+	if err := r.QueryRow(ctx, query, review.UserID, review.MediaID, review.MediaType, review.Rating, review.Comment).Scan(&review.ID, &review.CreatedAt, &review.UpdatedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, errs.NotFound(string(review.MediaType), "id", review.MediaID)
 		} else if errs.IsUniqueViolation(err, uniqueUserMediaConstraint) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed bug where created at and updated at werent coming back from db

<img width="1023" alt="Screenshot 2024-09-24 at 12 04 07 AM" src="https://github.com/user-attachments/assets/b97f0665-af87-489f-a1f4-4edd47e10427">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Some tests are included that test my code

## Screenshots:
<!--- If working on a backend ticket, screenshots or a walkthrough of successful API calls are included. -->
<!--- If working on a frontend ticket, screenshots/recording of new screens or functionality are included. -->
