### PR TITLE
Implemented GET endpoint for User Score (upvotes - downvotes + aura)

### DIFF
--- a/backend/internal/service/handler/users/user.go
+++ b/backend/internal/service/handler/users/user.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"github.com/google/uuid"
 	"platnm/internal/storage"
 
 	"github.com/gofiber/fiber/v2"
@@ -35,4 +36,22 @@ func (h *Handler) GetUserById(c *fiber.Ctx) error {
 	}
 
 	return c.Status(fiber.StatusOK).JSON(user)
+}
+
+func (h *Handler) CalculateScore(c *fiber.Ctx) error {
+	id := c.Params("id")
+
+	userUUID, err := uuid.Parse(id)
+	if err != nil {
+		return err
+	}
+
+	score, err := h.userRepository.CalculateScore(c.Context(), userUUID)
+
+	if err != nil {
+		print(err.Error(), "from transactions err ")
+		return err
+	}
+
+	return c.Status(fiber.StatusOK).JSON(score)
 }

--- a/backend/internal/service/handler/users/user.go
+++ b/backend/internal/service/handler/users/user.go
@@ -2,6 +2,7 @@ package users
 
 import (
 	"github.com/google/uuid"
+	"platnm/internal/errs"
 	"platnm/internal/storage"
 
 	"github.com/gofiber/fiber/v2"
@@ -40,6 +41,15 @@ func (h *Handler) GetUserById(c *fiber.Ctx) error {
 
 func (h *Handler) CalculateScore(c *fiber.Ctx) error {
 	id := c.Params("id")
+
+	exists, err := h.userRepository.UserExists(c.Context(), id)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return errs.NotFound("User", "userID", id)
+	}
 
 	userUUID, err := uuid.Parse(id)
 	if err != nil {

--- a/backend/internal/service/server.go
+++ b/backend/internal/service/server.go
@@ -48,6 +48,7 @@ func setupRoutes(app *fiber.App, config config.Config) {
 		r.Get("/", userHandler.GetUsers)
 		r.Get("/:id", userHandler.GetUserById)
 		r.Post("/follow", userHandler.FollowUnfollowUser)
+		r.Get("/score/:id", userHandler.CalculateScore)
 	})
 
 	app.Route("/reviews", func(r fiber.Router) {

--- a/backend/internal/storage/postgres/schema/user.go
+++ b/backend/internal/storage/postgres/schema/user.go
@@ -113,6 +113,8 @@ func (r *UserRepository) CalculateScore(ctx context.Context, id uuid.UUID) (int,
 		return 0, errs.NotFound("User", "userID", id)
 	}
 
+	// Coalesce returns first non-null value in the set of arguments, so if SUM returns null, 0 is defaulted to.
+	// urv, rec, and u are aliases to user_review_vote, recommendation, and user tables.
 	query := `
     SELECT 
         COALESCE((

--- a/backend/internal/storage/postgres/schema/user.go
+++ b/backend/internal/storage/postgres/schema/user.go
@@ -114,7 +114,7 @@ func (r *UserRepository) CalculateScore(ctx context.Context, id uuid.UUID) (int,
             FROM 
                 user_review_vote urv
             WHERE 
-                urv.user_id = u.id
+                urv.user_id = $1
         ), 0) + 
         COALESCE((
             SELECT 
@@ -122,12 +122,8 @@ func (r *UserRepository) CalculateScore(ctx context.Context, id uuid.UUID) (int,
             FROM 
                 recommendation rec
             WHERE 
-                rec.recommender_id = u.id
-        ), 0) AS score
-    FROM 
-        "user" u
-    WHERE 
-        u.id = $1
+                rec.recommender_id = $1
+        ), 0) AS score 
 `
 
 	var score int

--- a/backend/internal/storage/postgres/schema/user.go
+++ b/backend/internal/storage/postgres/schema/user.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"context"
-	"platnm/internal/errs"
 	"platnm/internal/models"
 
 	"github.com/google/uuid"
@@ -104,14 +103,6 @@ func (r *UserRepository) UnFollow(ctx context.Context, follower uuid.UUID, follo
 }
 
 func (r *UserRepository) CalculateScore(ctx context.Context, id uuid.UUID) (int, error) {
-	exists, err := r.UserExists(ctx, id.String())
-	if err != nil {
-		return 0, err
-	}
-
-	if !exists {
-		return 0, errs.NotFound("User", "userID", id)
-	}
 
 	// Coalesce returns first non-null value in the set of arguments, so if SUM returns null, 0 is defaulted to.
 	// urv, rec, and u are aliases to user_review_vote, recommendation, and user tables.
@@ -140,7 +131,7 @@ func (r *UserRepository) CalculateScore(ctx context.Context, id uuid.UUID) (int,
 `
 
 	var score int
-	err = r.db.QueryRow(ctx, query, id).Scan(&score)
+	err := r.db.QueryRow(ctx, query, id).Scan(&score)
 
 	if err != nil {
 		print(err.Error(), "from transactions err ")

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -14,6 +14,7 @@ type UserRepository interface {
 	FollowExists(ctx context.Context, follower uuid.UUID, following uuid.UUID) (bool, error)
 	Follow(ctx context.Context, follower uuid.UUID, following uuid.UUID) (bool, error)
 	UnFollow(ctx context.Context, follower uuid.UUID, following uuid.UUID) (bool, error)
+	CalculateScore(ctx context.Context, id uuid.UUID) (int, error)
 }
 
 type ReviewRepository interface {


### PR DESCRIPTION
## Description

Added an endpoint to allow for a GET request for a user score using the /users/score/:id endpoint.
Score is calculated: (upvotes - downvotes + aura)

The id in '.../score/:id' corresponds to the unique user id in the 'id' column in the 'user' table.

A user with the id of the path parameter must exist in the database, which is validated by 'UserExists.'

I followed the theme of some newly added methods and passed around the IDs as type 'uuid.UUID' instead of string--can modify if unnecessary.

The score is calculated by the 'CalculateScore' method, which relatively straight forward other than the SQL query. The query adds upvotes (user_review_vote.upvote column == true), subtracts downvotes (user_review_vote.upvote column == false), and adds aura points (recommendation.reaction column == true). 

If recommendation.reaction column is false or null, it is treated as 0. 

[Link to Ticket](https://github.com/GenerateNU/platnm/issues/64)

## How Has This Been Tested?

I have tested:
- Routing with an invalid user id (errors as expected). 
- Routing with a valid user id (uvr = FALSE, FALSE, TRUE, rec = TRUE, NULL, FALSE, TRUE) = 1
- Routing with a valid user id (uvr = FALSE, TRUE, TRUE, rec = TRUE, NULL, FALSE, TRUE) = 3
- Routing with a valid user id (uvr = FALSE, TRUE, TRUE, rec = TRUE, NULL, FALSE, FALSE) = 2
- Routing with a valid user id (no entries in uvr or rec) = 0
- Routing with a valid user id (uvr = FALSE, TRUE, TRUE, rec = TRUE, NULL, FALSE, FALSE) = 2 (with additional row in uvr with different user id to make sure only applicable rows are counted)


## Checklist:
- [Y] I have performed a self-review of my code
- [Y] I have commented my code, particularly in hard-to-understand areas
- [Y] Some tests are included that test my code

## Screenshots:
![image](https://github.com/user-attachments/assets/08abd409-19b2-4541-8d29-1ea9041a4182)
![image](https://github.com/user-attachments/assets/d272335f-2c1c-43b4-8022-6e09174099c2)
![image](https://github.com/user-attachments/assets/80aa4c58-b71e-40c7-b47d-0647065ee23a)
![image](https://github.com/user-attachments/assets/1b612608-643a-4ae9-8ef7-1067e8c8b1aa)
![image](https://github.com/user-attachments/assets/2465684c-6783-4d14-86ec-080a7fc56a05)
![image](https://github.com/user-attachments/assets/7b28d371-f7c2-4ac2-8e00-d1e769a55b65)
![image](https://github.com/user-attachments/assets/f8136c5c-daf3-4bbd-97c4-cbf508768d08)
![image](https://github.com/user-attachments/assets/0e22d70b-0ba5-43c7-8a5f-c2b8a078a3b5)
![image](https://github.com/user-attachments/assets/e58c458b-f7ea-4bc8-9be8-655de72b5cbe)
![image](https://github.com/user-attachments/assets/0714bac1-dbab-4046-9734-f78e135e4aa5)
![image](https://github.com/user-attachments/assets/672b4516-3726-412d-9757-aaafcf0ebb93)
![image](https://github.com/user-attachments/assets/99c47417-0f30-4ecb-a3a5-f046ba892186)
![image](https://github.com/user-attachments/assets/5d0694fe-3d10-4cb1-b5dc-163c49591407)
![image](https://github.com/user-attachments/assets/fbe5a47b-d8a1-4d9e-bf63-2c4f5a0e6628)


