### PR TITLE
Update follows to add a follower_at timestamp

### DIFF
--- a/backend/internal/supabase/migrations/20241008043459_update_follow_add_followed_at.sql
+++ b/backend/internal/supabase/migrations/20241008043459_update_follow_add_followed_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE follower
+ADD COLUMN followed_at timestamp with time zone default now() not null;

--- a/backend/internal/supabase/migrations/20241008043459_update_follow_add_followed_at.sql
+++ b/backend/internal/supabase/migrations/20241008043459_update_follow_add_followed_at.sql
@@ -1,2 +1,6 @@
 ALTER TABLE follower
 ADD COLUMN followed_at timestamp with time zone default now() not null;
+
+UPDATE follower
+SET followed_at = CURRENT_TIMESTAMP
+WHERE followed_at IS NULL;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Created a migration to update the follows table which add a followed_at timestamo that automatically populates with the current time when a new row is added. Will also backfill any existing rows with the current timestamp so nothing is null
[Link to Ticket](https://github.com/GenerateNU/platnm/issues/65#issue-2561915832)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Postman tests
Rows have the date:
<img width="731" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/4e87f778-f650-448c-93cc-d7e8e33df983">
When a new follow is added the followed_at row is populated with current datetime
<img width="802" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/11650b60-9357-4769-8d4f-fc32c2474ba2">
<img width="730" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/c2d99a56-5d28-474a-b570-8c66d00b0ddc">
^ old times are different from the first ss because I restarted the server

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Some tests are included that test my code

## Screenshots:
<!--- If working on a backend ticket, screenshots or a walkthrough of successful API calls are included. -->
<!--- If working on a frontend ticket, screenshots/recording of new screens or functionality are included. -->
