### PR TITLE
Enable react to friend's recommendation

### DIFF
--- a/backend/internal/service/handler/recommendation/react_to_recommendation.go
+++ b/backend/internal/service/handler/recommendation/react_to_recommendation.go
@@ -1,0 +1,62 @@
+package recommendation
+
+import (
+	"platnm/internal/errs"
+	"platnm/internal/models"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type RecommendationReaction struct {
+	RecommendationID int    `json:"recommendation_id"`
+	UserID           string `json:"user_id"`
+	Reaction         bool   `json:"reaction"`
+}
+
+func (h *Handler) ReactToRecommendation(c *fiber.Ctx) error {
+
+	rec_id := c.Params("id")
+	recommendation, err := h.recommendationRepository.GetRecommendation(c.Context(), rec_id)
+
+	reaction := RecommendationReaction{}
+
+	if err != nil {
+		return err
+	}
+
+	if recommendation == nil {
+		return errs.NotFound("Recommendation", "id", rec_id)
+	}
+
+	// verify that the format of the request matches the review
+	if err := c.BodyParser(&reaction); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+	}
+
+	// only the recommendee can react to the message
+	if recommendation.RecommendeeId != reaction.UserID {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "User ID does not match the recommendee ID."})
+	}
+
+	// making the updated recommendation with the new reaction
+	updatedRecommendation := &models.Recommendation{
+		ID:            recommendation.ID,
+		MediaType:     recommendation.MediaType,
+		MediaID:       recommendation.MediaID,
+		RecommendeeId: recommendation.RecommendeeId,
+		RecommenderId: recommendation.RecommenderId,
+		Reaction:      &reaction.Reaction,
+		CreatedAt:     recommendation.CreatedAt,
+	}
+
+	// change the reaction of the recommendation
+	update_err := h.recommendationRepository.UpdateRecommendation(c.Context(), updatedRecommendation)
+
+	if update_err != nil {
+		return update_err
+	}
+
+	// send a stauts that everything is okay
+	return c.SendStatus(fiber.StatusOK)
+
+}

--- a/backend/internal/service/handler/recommendation/react_to_recommendation.go
+++ b/backend/internal/service/handler/recommendation/react_to_recommendation.go
@@ -8,20 +8,18 @@ import (
 )
 
 type RecommendationReaction struct {
-	RecommendationID int    `json:"recommendation_id"`
-	UserID           string `json:"user_id"`
-	Reaction         bool   `json:"reaction"`
+	UserID   string `json:"user_id"`
+	Reaction bool   `json:"reaction"`
 }
 
 func (h *Handler) ReactToRecommendation(c *fiber.Ctx) error {
-
-	rec_id := c.Params("id")
+	rec_id := c.Params("recommendationId")
 	recommendation, err := h.recommendationRepository.GetRecommendation(c.Context(), rec_id)
 
 	reaction := RecommendationReaction{}
 
 	if err != nil {
-		return err
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid recommendation ID.c"})
 	}
 
 	if recommendation == nil {

--- a/backend/internal/service/handler/reviews/update_review.go
+++ b/backend/internal/service/handler/reviews/update_review.go
@@ -1,10 +1,11 @@
 package reviews
 
 import (
-	"github.com/gofiber/fiber/v2"
 	"platnm/internal/models"
 	"strconv"
 	"time"
+
+	"github.com/gofiber/fiber/v2"
 
 	"platnm/internal/constants"
 	"platnm/internal/errs"

--- a/backend/internal/service/server.go
+++ b/backend/internal/service/server.go
@@ -73,6 +73,7 @@ func setupRoutes(app *fiber.App, config config.Config) {
 	recommendationHandler := recommendation.NewHandler(repository.Recommendation)
 	app.Route("/recommendation", func(r fiber.Router) {
 		r.Post("/", recommendationHandler.CreateRecommendation)
+		r.Patch("/:recommendationId", recommendationHandler.ReactToRecommendation)
 	})
 
 	// this store can be passed to other oauth handlers that need to manage state/verifier values

--- a/backend/internal/storage/postgres/schema/recommendation.go
+++ b/backend/internal/storage/postgres/schema/recommendation.go
@@ -59,7 +59,7 @@ func (r *RecommendationRepository) GetRecommendation(ctx context.Context, id str
 
 	row := r.QueryRow(ctx, `SELECT * FROM recommendation WHERE id = $1`, id)
 
-	err := row.Scan(&rec.ID, &rec.MediaType, &rec.MediaID, &rec.RecommendeeId, &rec.RecommenderId, &rec.Reaction, &rec.CreatedAt)
+	err := row.Scan(&rec.ID, &rec.MediaType, &rec.MediaID, &rec.RecommenderId, &rec.RecommendeeId, &rec.CreatedAt, &rec.Reaction)
 
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/backend/internal/storage/postgres/schema/recommendation.go
+++ b/backend/internal/storage/postgres/schema/recommendation.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"platnm/internal/errs"
 	"platnm/internal/models"
@@ -50,6 +51,41 @@ func (r *RecommendationRepository) CreateRecommendation(ctx context.Context, rec
 	}
 
 	return recommendation, nil
+}
+
+func (r *RecommendationRepository) GetRecommendation(ctx context.Context, id string) (*models.Recommendation, error) {
+
+	var rec models.Recommendation
+
+	row := r.QueryRow(ctx, `SELECT * FROM recommendation WHERE id = $1`, id)
+
+	err := row.Scan(&rec.ID, &rec.MediaType, &rec.MediaID, &rec.RecommendeeId, &rec.RecommenderId, &rec.Reaction, &rec.CreatedAt)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &rec, nil
+
+}
+
+func (r *RecommendationRepository) UpdateRecommendation(ctx context.Context, recommendation *models.Recommendation) error {
+
+	query := `
+		UPDATE recommendation
+		SET reaction = $1
+		WHERE id = $2
+	`
+
+	_, err := r.Exec(ctx, query, recommendation.Reaction, recommendation.ID)
+
+	if err != nil {
+		return err
+	}
+	return nil
+
 }
 
 func NewRecommendationRepository(db *pgxpool.Pool) *RecommendationRepository {

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -34,6 +34,8 @@ type MediaRepository interface {
 
 type RecommendationRepository interface {
 	CreateRecommendation(ctx context.Context, recommendation *models.Recommendation) (*models.Recommendation, error)
+	GetRecommendation(ctx context.Context, id string) (*models.Recommendation, error)
+	UpdateRecommendation(ctx context.Context, recommendation *models.Recommendation) (error)
 }
 
 // Repository storage of all repositories.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added PATCH endpoint to allow recomendees to react to recommendations. The behavior is as follows: 
- If the userID matches with the recomendee's ID in the database, make the change to the reaction. 
- If the userID does not match with the recomendee's ID but the recommendation exists, return error that indicates so. 
- If the recommendation does not exist, return error that indicates so. 

Shoutout to @zcroft27 for writing the update review endpoint and giving me a template. 

[Link to Ticket](https://github.com/GenerateNU/platnm/issues/72)

## How Has This Been Tested?
See screenshots via Postman. 

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [  ] Some tests are included that test my code

## Screenshots:

Invalid recommendation ID: 
<img width="782" alt="Screenshot 2024-10-09 at 10 56 48 PM" src="https://github.com/user-attachments/assets/f101019d-9e38-44a7-9103-dfa0cd88d27b">

UserID does not match recomendee ID:
![image](https://github.com/user-attachments/assets/db2c201b-3a80-4b2f-9ae7-6efcb8bc2466)

Successful update to the reaction: 
<img width="777" alt="Screenshot 2024-10-09 at 10 52 46 PM" src="https://github.com/user-attachments/assets/184a175e-d026-4ae2-98ed-91ecabe460c6">