### PR TITLE
Filter media by media type, either album or track

### DIFF
--- a/backend/internal/models/media.go
+++ b/backend/internal/models/media.go
@@ -1,12 +1,15 @@
 package models
 
-import "time"
+import (
+	"time"
+)
 
 type MediaType string
 
 const (
 	TrackMedia MediaType = "track"
 	AlbumMedia MediaType = "album"
+	BothMedia  MediaType = "both"
 )
 
 // A Media interface that both Album and Track must implement. T

--- a/backend/internal/service/handler/media/get_media.go
+++ b/backend/internal/service/handler/media/get_media.go
@@ -2,14 +2,27 @@ package media
 
 import (
 	"platnm/internal/errs"
+	"platnm/internal/models"
 	"platnm/internal/service/utils"
 
 	"github.com/gofiber/fiber/v2"
 )
 
 func (h *Handler) GetMediaByName(c *fiber.Ctx) error {
-	name := c.Params("name")
-	medias, _ := h.mediaRepository.GetMediaByName(c.Context(), name)
+    name := c.Params("name")
+    typeString := c.Query("media_type")
+    
+    var mediaType models.MediaType 
+    
+    switch typeString {
+    case "album":
+        mediaType = models.AlbumMedia 
+    case "track":
+        mediaType = models.TrackMedia
+	case "":
+		mediaType = models.BothMedia
+	}
+	medias, _ := h.mediaRepository.GetMediaByName(c.Context(), name, mediaType)
 	return c.Status(fiber.StatusOK).JSON(medias)
 }
 

--- a/backend/internal/storage/postgres/schema/media.go
+++ b/backend/internal/storage/postgres/schema/media.go
@@ -147,7 +147,6 @@ func (r *MediaRepository) AddArtist(ctx context.Context, artist *models.Artist) 
 
 func (r *MediaRepository) GetExistingAlbumBySpotifyID(ctx context.Context, id string) (*int, error) {
 	var albumId int
-	fmt.Println("looking for album with spotify id: ", id)
 	err := r.QueryRow(ctx, `SELECT id FROM album WHERE spotify_id = $1`, id).Scan(&albumId)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -228,22 +227,17 @@ func (r *MediaRepository) GetMediaByName(ctx context.Context, name string, media
 				&album.GenreID,
 				&album.SpotifyID,
 			); err != nil {
-				fmt.Println("Error retrieving media:", err)
 				return nil, err
 			}
 			album.MediaType = models.AlbumMedia
 			medias = append(medias, album)
-			print("here")
 		}
 	}
 
 	if mediaType == models.TrackMedia || mediaType == models.BothMedia {
 
-		print("we inside &2 ")
-
 		trackRows, trackErr := r.Query(ctx, trackQuery, name)
 		if trackErr != nil {
-			print("are we hererererere")
 			return nil, trackErr
 		}
 		defer trackRows.Close()
@@ -259,12 +253,10 @@ func (r *MediaRepository) GetMediaByName(ctx context.Context, name string, media
 				&track.Cover,
 				&track.AlbumTitle,
 			); err != nil {
-				print("ajsdhfjasdhfkajsdhfk")
 				return nil, err
 			}
 			track.MediaType = models.TrackMedia
 			medias = append(medias, track)
-			print("here")
 		}
 
 	}

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -31,7 +31,7 @@ type ReviewRepository interface {
 }
 
 type MediaRepository interface {
-	GetMediaByName(ctx context.Context, name string) ([]models.Media, error)
+	GetMediaByName(ctx context.Context, name string, mediaType models.MediaType) ([]models.Media, error)
 	GetMediaByDate(ctx context.Context) ([]models.Media, error)
 	GetMediaByReviews(ctx context.Context, limit, offset int) ([]models.MediaWithReviewCount, error)
 	GetExistingArtistBySpotifyID(ctx context.Context, id string) (*int, error)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Edit media endpoint to filter by the media type, either by album or track, or both if nothing specified. 
<!--- Describe your changes in detail -->
[Link to Ticket](https://github.com/GenerateNU/platnm/issues/85)

## How Has This Been Tested?
See postman screenshots.
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
- [xI have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] Some tests are included that test my code

## Screenshots:
Filter by album
<img width="779" alt="Screenshot 2024-10-18 at 4 35 31 PM" src="https://github.com/user-attachments/assets/7a8d0407-ea8f-4d05-9116-363cf7e74447">
Filter by media
<img width="778" alt="Screenshot 2024-10-18 at 4 35 45 PM" src="https://github.com/user-attachments/assets/a6b49f29-9626-409e-b477-ee813a772dea">
No filter
<img width="777" alt="Screenshot 2024-10-18 at 4 37 32 PM" src="https://github.com/user-attachments/assets/3b1ec7f8-881c-4530-8537-a034bfbfc436">
No results
<img width="777" alt="Screenshot 2024-10-18 at 4 37 42 PM" src="https://github.com/user-attachments/assets/4d1e4259-d061-4d7c-ab7c-678f90fac49a">
<!--- If working on a backend ticket, screenshots or a walkthrough of successful API calls are included. -->
<!--- If working on a frontend ticket, screenshots/recording of new screens or functionality are included. -->
