### PR TITLE
Auth spotify client middleware

### DIFF
--- a/backend/internal/constants/auth.go
+++ b/backend/internal/constants/auth.go
@@ -3,5 +3,5 @@ package constants
 import "time"
 
 const (
-	SessionDuration = 5 * time.Minute
+	SessionDuration = 24 * time.Hour
 )

--- a/backend/internal/service/handler/oauth/platnm/handler.go
+++ b/backend/internal/service/handler/oauth/platnm/handler.go
@@ -2,15 +2,15 @@ package platnm
 
 import (
 	"platnm/internal/config"
-	"platnm/internal/service/handler/oauth"
+	"platnm/internal/service/session"
 )
 
 type Handler struct {
-	store  *oauth.UserStateStore
+	store  *session.SessionStore
 	config config.Supabase
 }
 
-func NewHandler(store *oauth.UserStateStore, config config.Supabase) *Handler {
+func NewHandler(store *session.SessionStore, config config.Supabase) *Handler {
 	return &Handler{
 		store:  store,
 		config: config,

--- a/backend/internal/service/handler/oauth/platnm/handler.go
+++ b/backend/internal/service/handler/oauth/platnm/handler.go
@@ -6,11 +6,11 @@ import (
 )
 
 type Handler struct {
-	store  *oauth.StateStore
+	store  *oauth.UserStateStore
 	config config.Supabase
 }
 
-func NewHandler(store *oauth.StateStore, config config.Supabase) *Handler {
+func NewHandler(store *oauth.UserStateStore, config config.Supabase) *Handler {
 	return &Handler{
 		store:  store,
 		config: config,

--- a/backend/internal/service/handler/oauth/session.go
+++ b/backend/internal/service/handler/oauth/session.go
@@ -3,39 +3,45 @@ package oauth
 import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/session"
+	"github.com/google/uuid"
 )
 
-const valueKey = "state"
+const valueKey = "userState"
 
-type StateStore struct {
+type UserStateStore struct {
 	*session.Store
 }
 
-func NewStateStore(config session.Config) *StateStore {
-	store := &StateStore{
+type UserState struct {
+	User  uuid.UUID
+	State string
+}
+
+func NewStateStore(config session.Config) *UserStateStore {
+	store := &UserStateStore{
 		session.New(config),
 	}
 
 	return store
 }
 
-func (s *StateStore) SetState(c *fiber.Ctx, state string) error {
+func (s *UserStateStore) SetState(c *fiber.Ctx, userState UserState) error {
 	sess, err := s.Get(c)
 	if err != nil {
 		return err
 	}
 
-	sess.Set(valueKey, state)
+	sess.Set(valueKey, userState)
 	if err := sess.Save(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (s *StateStore) GetState(c *fiber.Ctx) (string, error) {
+func (s *UserStateStore) GetState(c *fiber.Ctx) (UserState, error) {
 	sess, err := s.Get(c)
 	if err != nil {
-		return "", err
+		return UserState{}, err
 	}
-	return sess.Get(valueKey).(string), nil
+	return sess.Get(valueKey).(UserState), nil
 }

--- a/backend/internal/service/handler/oauth/spotify/begin.go
+++ b/backend/internal/service/handler/oauth/spotify/begin.go
@@ -1,14 +1,18 @@
 package spotify
 
 import (
-	"net/http"
-	"platnm/internal/constants"
 	"platnm/internal/service/handler/oauth"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 )
 
 func (h *Handler) Begin(c *fiber.Ctx) error {
+	uid, err := uuid.Parse(c.Query("userID"))
+	if err != nil {
+		return err
+	}
+
 	state, err := oauth.GenerateState()
 	if err != nil {
 		return err
@@ -16,10 +20,11 @@ func (h *Handler) Begin(c *fiber.Ctx) error {
 
 	url := h.authenticator.AuthURL(state)
 
-	if err := h.store.SetState(c, state); err != nil {
+	if err := h.store.SetState(c, oauth.UserState{User: uid, State: state}); err != nil {
 		return err
 	}
 
-	c.Set(constants.HeaderRedirect, url)
-	return c.SendStatus(http.StatusFound)
+	// c.Set(constants.HeaderRedirect, url)
+	// return c.SendStatus(http.StatusFound)
+	return c.Redirect(url)
 }

--- a/backend/internal/service/handler/oauth/spotify/begin.go
+++ b/backend/internal/service/handler/oauth/spotify/begin.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (h *Handler) Begin(c *fiber.Ctx) error {
-	uid, err := uuid.Parse(c.Query("userID"))
+	uid, err := uuid.Parse(c.Params("userID"))
 	if err != nil {
 		return err
 	}

--- a/backend/internal/service/handler/oauth/spotify/begin.go
+++ b/backend/internal/service/handler/oauth/spotify/begin.go
@@ -2,6 +2,7 @@ package spotify
 
 import (
 	"platnm/internal/service/handler/oauth"
+	"platnm/internal/service/session"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
@@ -20,7 +21,11 @@ func (h *Handler) Begin(c *fiber.Ctx) error {
 
 	url := h.authenticator.AuthURL(state)
 
-	if err := h.store.SetState(c, oauth.UserState{User: uid, State: state}); err != nil {
+	// should only need to store state value in store
+	// since user id should already be attached to session
+	// since user needs to be authenticated to link account with spotify
+	// but until id is stored in session, just store like this
+	if err := h.store.SetState(c, session.UserState{User: uid, State: state}); err != nil {
 		return err
 	}
 

--- a/backend/internal/service/handler/oauth/spotify/callback.go
+++ b/backend/internal/service/handler/oauth/spotify/callback.go
@@ -1,9 +1,9 @@
 package spotify
 
 import (
-	"fmt"
 	"net/http"
 	"platnm/internal/constants"
+	"platnm/internal/service/handler/oauth"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/adaptor"
@@ -14,7 +14,6 @@ func (h *Handler) Callback(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("User state: %+v\n", userState)
 
 	req, err := adaptor.ConvertRequest(c, false)
 	if err != nil {
@@ -26,7 +25,12 @@ func (h *Handler) Callback(c *fiber.Ctx) error {
 		return err
 	}
 
-	if err := h.userAuthRepository.SetToken(c.Context(), userState.User, token); err != nil {
+	encryptedToken, err := oauth.EncryptToken(token)
+	if err != nil {
+		return err
+	}
+
+	if err := h.userAuthRepository.SetToken(c.Context(), userState.User, encryptedToken); err != nil {
 		return err
 	}
 

--- a/backend/internal/service/handler/oauth/spotify/callback.go
+++ b/backend/internal/service/handler/oauth/spotify/callback.go
@@ -1,7 +1,7 @@
 package spotify
 
 import (
-	"log/slog"
+	"fmt"
 	"net/http"
 	"platnm/internal/constants"
 
@@ -10,23 +10,25 @@ import (
 )
 
 func (h *Handler) Callback(c *fiber.Ctx) error {
-	state, err := h.store.GetState(c)
+	userState, err := h.store.GetState(c)
 	if err != nil {
 		return err
 	}
+	fmt.Printf("User state: %+v\n", userState)
 
 	req, err := adaptor.ConvertRequest(c, false)
 	if err != nil {
 		return err
 	}
 
-	token, err := h.authenticator.Token(c.Context(), state, req)
+	token, err := h.authenticator.Token(c.Context(), userState.State, req)
 	if err != nil {
 		return err
 	}
 
-	slog.Info("Access token:", "token", token.AccessToken)
-	slog.Info("Refresh token:", "token", token.RefreshToken)
+	if err := h.userAuthRepository.SetToken(c.Context(), userState.User, token); err != nil {
+		return err
+	}
 
 	c.Set(constants.HeaderRedirect, "http://127.0.0.1:3000")
 	return c.SendStatus(http.StatusFound)

--- a/backend/internal/service/handler/oauth/spotify/handler.go
+++ b/backend/internal/service/handler/oauth/spotify/handler.go
@@ -3,25 +3,28 @@ package spotify
 import (
 	"platnm/internal/config"
 	"platnm/internal/service/handler/oauth"
+	"platnm/internal/storage"
 
 	spotifyauth "github.com/zmb3/spotify/v2/auth"
 )
 
 type Handler struct {
-	store         *oauth.StateStore
-	authenticator *spotifyauth.Authenticator
+	store              *oauth.UserStateStore
+	authenticator      *spotifyauth.Authenticator
+	userAuthRepository storage.UserAuthRepository
 }
 
-func NewHandler(store *oauth.StateStore, config config.Spotify) *Handler {
+func NewHandler(store *oauth.UserStateStore, config config.Spotify, userAuthRepository storage.UserAuthRepository) *Handler {
 	authenticator := spotifyauth.New(
 		spotifyauth.WithRedirectURL(config.RedirectURI),
-		spotifyauth.WithScopes(spotifyauth.ScopeUserReadPrivate),
+		spotifyauth.WithScopes(spotifyauth.ScopeUserReadPrivate, spotifyauth.ScopePlaylistReadPrivate, spotifyauth.ScopePlaylistReadCollaborative),
 		spotifyauth.WithClientID(config.ClientID),
 		spotifyauth.WithClientSecret(config.ClientSecret),
 	)
 
 	return &Handler{
-		store:         store,
-		authenticator: authenticator,
+		store:              store,
+		authenticator:      authenticator,
+		userAuthRepository: userAuthRepository,
 	}
 }

--- a/backend/internal/service/handler/oauth/spotify/handler.go
+++ b/backend/internal/service/handler/oauth/spotify/handler.go
@@ -2,19 +2,19 @@ package spotify
 
 import (
 	"platnm/internal/config"
-	"platnm/internal/service/handler/oauth"
+	"platnm/internal/service/session"
 	"platnm/internal/storage"
 
 	spotifyauth "github.com/zmb3/spotify/v2/auth"
 )
 
 type Handler struct {
-	store              *oauth.UserStateStore
+	store              *session.SessionStore
 	authenticator      *spotifyauth.Authenticator
 	userAuthRepository storage.UserAuthRepository
 }
 
-func NewHandler(store *oauth.UserStateStore, config config.Spotify, userAuthRepository storage.UserAuthRepository) *Handler {
+func NewHandler(store *session.SessionStore, config config.Spotify, userAuthRepository storage.UserAuthRepository) *Handler {
 	authenticator := spotifyauth.New(
 		spotifyauth.WithRedirectURL(config.RedirectURI),
 		spotifyauth.WithScopes(spotifyauth.ScopeUserReadPrivate, spotifyauth.ScopePlaylistReadPrivate, spotifyauth.ScopePlaylistReadCollaborative),

--- a/backend/internal/service/handler/oauth/token.go
+++ b/backend/internal/service/handler/oauth/token.go
@@ -1,0 +1,103 @@
+package oauth
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+	"sync"
+
+	go_json "github.com/goccy/go-json"
+
+	"golang.org/x/oauth2"
+)
+
+const (
+	// nonce size is 12 for GCM according to cipher package
+	nonceSize int = 12
+
+	// key should be 16 or 32 bytes
+	key = "abcdefghijklmnopqrstuvwxyz123456"
+)
+
+type nonce struct {
+	data []byte
+}
+
+var noncePool = sync.Pool{
+	New: func() interface{} {
+		return &nonce{data: make([]byte, nonceSize)}
+	},
+}
+
+func getNonce() *nonce {
+	return noncePool.Get().(*nonce)
+}
+
+func putNonce(n *nonce) {
+	noncePool.Put(n)
+}
+
+// pointer receiver spotifyauth.Authenticator.Token() returns *oauth2.Token
+func EncryptToken(token *oauth2.Token) (string, error) {
+	data, err := go_json.Marshal(token)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := getNonce()
+	defer putNonce(nonce)
+
+	block, err := aes.NewCipher([]byte(key))
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := io.ReadFull(rand.Reader, nonce.data); err != nil {
+		return "", err
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	ciphertext := aesgcm.Seal(nil, nonce.data, data, nil)
+
+	combined := append(nonce.data, ciphertext...)
+
+	return base64.URLEncoding.EncodeToString(combined), nil
+}
+
+func DecryptToken(encodedCiphertext string) (oauth2.Token, error) {
+	combined, err := base64.URLEncoding.DecodeString(encodedCiphertext)
+	if err != nil {
+		return oauth2.Token{}, err
+	}
+
+	nonce := combined[:nonceSize]
+	ciphertext := combined[nonceSize:]
+
+	block, err := aes.NewCipher([]byte(key))
+	if err != nil {
+		return oauth2.Token{}, err
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return oauth2.Token{}, err
+	}
+
+	plaintext, err := aesgcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return oauth2.Token{}, err
+	}
+
+	var token oauth2.Token
+	if err := go_json.Unmarshal(plaintext, &token); err != nil {
+		return oauth2.Token{}, err
+	}
+
+	return token, nil
+}

--- a/backend/internal/service/handler/spotify/current_user_playlists.go
+++ b/backend/internal/service/handler/spotify/current_user_playlists.go
@@ -1,0 +1,21 @@
+package spotify
+
+import (
+	"platnm/internal/service/ctxt"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func (h *SpotifyHandler) GetCurrentUserPlaylists(c *fiber.Ctx) error {
+	client, err := ctxt.GetSpotifyClient(c)
+	if err != nil {
+		return err
+	}
+
+	playlists, err := client.CurrentUsersPlaylists(c.Context())
+	if err != nil {
+		return err
+	}
+
+	return c.Status(fiber.StatusOK).JSON(playlists)
+}

--- a/backend/internal/service/middleware/spotify/spotify.go
+++ b/backend/internal/service/middleware/spotify/spotify.go
@@ -3,6 +3,7 @@ package spotify
 import (
 	"platnm/internal/config"
 	"platnm/internal/service/ctxt"
+	"platnm/internal/service/handler/oauth"
 	"platnm/internal/storage"
 
 	"github.com/gofiber/fiber/v2"
@@ -36,7 +37,12 @@ func (m *Middleware) WithAuthenticatedSpotifyClient() fiber.Handler {
 			return err
 		}
 
-		token, err := m.userAuthRepository.GetToken(c.Context(), uid)
+		encryptedToken, err := m.userAuthRepository.GetToken(c.Context(), uid)
+		if err != nil {
+			return err
+		}
+
+		token, err := oauth.DecryptToken(encryptedToken)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/service/middleware/spotify/spotify.go
+++ b/backend/internal/service/middleware/spotify/spotify.go
@@ -68,6 +68,8 @@ func (m *Middleware) WithAuthenticatedSpotifyClient() fiber.Handler {
 		httpClient := authenticator.Client(c.Context(), &token)
 		client = spotify.New(httpClient)
 
+		m.sessionStore.SetAuthSpotifyClient(c, client)
+
 		ctxt.SetSpotifyClient(c, client)
 		return c.Next()
 	}
@@ -98,6 +100,8 @@ func (m *Middleware) WithSpotifyClient() fiber.Handler {
 
 		httpClient := spotifyauth.Authenticator{}.Client(c.Context(), token)
 		client = spotify.New(httpClient)
+
+		m.sessionStore.SetClientCredsSpotifyClient(c, client)
 
 		ctxt.SetSpotifyClient(c, client)
 		return c.Next()

--- a/backend/internal/service/middleware/spotify/spotify.go
+++ b/backend/internal/service/middleware/spotify/spotify.go
@@ -68,7 +68,9 @@ func (m *Middleware) WithAuthenticatedSpotifyClient() fiber.Handler {
 		httpClient := authenticator.Client(c.Context(), &token)
 		client = spotify.New(httpClient)
 
-		m.sessionStore.SetAuthSpotifyClient(c, client)
+		if err := m.sessionStore.SetAuthSpotifyClient(c, client); err != nil {
+			return err
+		}
 
 		ctxt.SetSpotifyClient(c, client)
 		return c.Next()
@@ -101,7 +103,9 @@ func (m *Middleware) WithSpotifyClient() fiber.Handler {
 		httpClient := spotifyauth.Authenticator{}.Client(c.Context(), token)
 		client = spotify.New(httpClient)
 
-		m.sessionStore.SetClientCredsSpotifyClient(c, client)
+		if err := m.sessionStore.SetClientCredsSpotifyClient(c, client); err != nil {
+			return err
+		}
 
 		ctxt.SetSpotifyClient(c, client)
 		return c.Next()

--- a/backend/internal/service/middleware/spotify/spotify.go
+++ b/backend/internal/service/middleware/spotify/spotify.go
@@ -3,8 +3,10 @@ package spotify
 import (
 	"platnm/internal/config"
 	"platnm/internal/service/ctxt"
+	"platnm/internal/storage"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 	spotifyauth "github.com/zmb3/spotify/v2/auth"
 
 	"github.com/zmb3/spotify/v2"
@@ -12,14 +14,43 @@ import (
 )
 
 type Middleware struct {
-	clientID     string
-	clientSecret string
+	clientID           string
+	clientSecret       string
+	redirectURI        string
+	userAuthRepository storage.UserAuthRepository
 }
 
-func NewMiddleware(config config.Spotify) *Middleware {
+func NewMiddleware(config config.Spotify, userAuthRepository storage.UserAuthRepository) *Middleware {
 	return &Middleware{
-		clientID:     config.ClientID,
-		clientSecret: config.ClientSecret,
+		clientID:           config.ClientID,
+		clientSecret:       config.ClientSecret,
+		redirectURI:        config.RedirectURI,
+		userAuthRepository: userAuthRepository,
+	}
+}
+
+func (m *Middleware) WithAuthenticatedSpotifyClient() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		uid, err := uuid.Parse(c.Params("userID"))
+		if err != nil {
+			return err
+		}
+
+		token, err := m.userAuthRepository.GetToken(c.Context(), uid)
+		if err != nil {
+			return err
+		}
+
+		// client id and secret are required to refresh the token
+		authenticator := spotifyauth.New(
+			spotifyauth.WithClientID(m.clientID),
+			spotifyauth.WithClientSecret(m.clientSecret),
+		)
+		httpClient := authenticator.Client(c.Context(), &token)
+		client := spotify.New(httpClient)
+
+		ctxt.SetSpotifyClient(c, client)
+		return c.Next()
 	}
 }
 
@@ -36,7 +67,7 @@ func (m *Middleware) WithSpotifyClient() fiber.Handler {
 			return err
 		}
 
-		httpClient := spotifyauth.New().Client(c.Context(), token)
+		httpClient := spotifyauth.Authenticator{}.Client(c.Context(), token)
 		client := spotify.New(httpClient)
 
 		ctxt.SetSpotifyClient(c, client)

--- a/backend/internal/service/server.go
+++ b/backend/internal/service/server.go
@@ -44,7 +44,7 @@ func setupRoutes(app *fiber.App, config config.Config) {
 	sessionStore := platnm_session.NewSessionStore(session.Config{
 		Storage:    memory.New(),
 		Expiration: constants.SessionDuration,
-		// KeyLookup:  "header:" + constants.HeaderSession,
+		KeyLookup:  "header:" + constants.HeaderSession,
 	})
 
 	app.Get("/health", func(c *fiber.Ctx) error {

--- a/backend/internal/service/server.go
+++ b/backend/internal/service/server.go
@@ -96,7 +96,7 @@ func setupRoutes(app *fiber.App, config config.Config) {
 		r.Route("/spotify", func(r fiber.Router) {
 			h := spotify_oauth_handler.NewHandler(store, config.Spotify, repository.UserAuth)
 
-			r.Get("/begin", h.Begin)
+			r.Get("/begin/:userID", h.Begin)
 			r.Get("/callback", h.Callback)
 		})
 		r.Route("/platnm", func(r fiber.Router) {

--- a/backend/internal/service/session/session.go
+++ b/backend/internal/service/session/session.go
@@ -1,0 +1,21 @@
+package session
+
+import (
+	"github.com/gofiber/fiber/v2/middleware/session"
+	"github.com/zmb3/spotify/v2"
+)
+
+type SessionStore struct {
+	*session.Store
+}
+
+func NewSessionStore(config session.Config) *SessionStore {
+	store := &SessionStore{
+		session.New(config),
+	}
+
+	store.RegisterType(UserState{})
+	store.RegisterType(spotify.Client{})
+
+	return store
+}

--- a/backend/internal/service/session/spotify.go
+++ b/backend/internal/service/session/spotify.go
@@ -1,0 +1,55 @@
+package session
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/zmb3/spotify/v2"
+)
+
+const (
+	authSpotifyClientKey        = "authSpotifyClient"
+	clientCredsSpotifyClientKey = "clientCredsSpotifyClient"
+)
+
+func (u *SessionStore) SetAuthSpotifyClient(c *fiber.Ctx, client *spotify.Client) error {
+	sess, err := u.Get(c)
+	if err != nil {
+		return err
+	}
+
+	sess.Set(authSpotifyClientKey, client)
+	if err := sess.Save(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (u *SessionStore) GetAuthSpotifyClient(c *fiber.Ctx) (*spotify.Client, error) {
+	sess, err := u.Get(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return sess.Get(authSpotifyClientKey).(*spotify.Client), nil
+}
+
+func (u *SessionStore) SetClientCredsSpotifyClient(c *fiber.Ctx, client *spotify.Client) error {
+	sess, err := u.Get(c)
+	if err != nil {
+		return err
+	}
+
+	sess.Set(clientCredsSpotifyClientKey, client)
+	if err := sess.Save(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (u *SessionStore) GetClientCredsSpotifyClient(c *fiber.Ctx) (*spotify.Client, error) {
+	sess, err := u.Get(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return sess.Get(clientCredsSpotifyClientKey).(*spotify.Client), nil
+}

--- a/backend/internal/service/session/spotify.go
+++ b/backend/internal/service/session/spotify.go
@@ -29,7 +29,12 @@ func (u *SessionStore) GetAuthSpotifyClient(c *fiber.Ctx) (*spotify.Client, erro
 		return nil, err
 	}
 
-	return sess.Get(authSpotifyClientKey).(*spotify.Client), nil
+	v := sess.Get(authSpotifyClientKey)
+	if v == nil {
+		return nil, nil
+	}
+
+	return v.(*spotify.Client), nil
 }
 
 func (u *SessionStore) SetClientCredsSpotifyClient(c *fiber.Ctx, client *spotify.Client) error {
@@ -51,5 +56,10 @@ func (u *SessionStore) GetClientCredsSpotifyClient(c *fiber.Ctx) (*spotify.Clien
 		return nil, err
 	}
 
-	return sess.Get(clientCredsSpotifyClientKey).(*spotify.Client), nil
+	v := sess.Get(clientCredsSpotifyClientKey)
+	if v == nil {
+		return nil, nil
+	}
+
+	return v.(*spotify.Client), nil
 }

--- a/backend/internal/service/session/state.go
+++ b/backend/internal/service/session/state.go
@@ -30,5 +30,10 @@ func (s *SessionStore) GetState(c *fiber.Ctx) (UserState, error) {
 	if err != nil {
 		return UserState{}, err
 	}
-	return sess.Get(valueKey).(UserState), nil
+	v := sess.Get(valueKey)
+	if v == nil {
+		return UserState{}, nil
+	}
+
+	return v.(UserState), nil
 }

--- a/backend/internal/service/session/state.go
+++ b/backend/internal/service/session/state.go
@@ -1,31 +1,18 @@
-package oauth
+package session
 
 import (
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/middleware/session"
 	"github.com/google/uuid"
 )
 
 const valueKey = "userState"
-
-type UserStateStore struct {
-	*session.Store
-}
 
 type UserState struct {
 	User  uuid.UUID
 	State string
 }
 
-func NewStateStore(config session.Config) *UserStateStore {
-	store := &UserStateStore{
-		session.New(config),
-	}
-
-	return store
-}
-
-func (s *UserStateStore) SetState(c *fiber.Ctx, userState UserState) error {
+func (s *SessionStore) SetState(c *fiber.Ctx, userState UserState) error {
 	sess, err := s.Get(c)
 	if err != nil {
 		return err
@@ -38,7 +25,7 @@ func (s *UserStateStore) SetState(c *fiber.Ctx, userState UserState) error {
 	return nil
 }
 
-func (s *UserStateStore) GetState(c *fiber.Ctx) (UserState, error) {
+func (s *SessionStore) GetState(c *fiber.Ctx) (UserState, error) {
 	sess, err := s.Get(c)
 	if err != nil {
 		return UserState{}, err

--- a/backend/internal/storage/postgres/schema/user_auth.go
+++ b/backend/internal/storage/postgres/schema/user_auth.go
@@ -1,0 +1,56 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/oauth2"
+)
+
+type UserAuthRepository struct {
+	*pgxpool.Pool
+}
+
+func (r *UserAuthRepository) GetToken(ctx context.Context, id uuid.UUID) (oauth2.Token, error) {
+	const query string = `
+	SELECT access_token, token_type, refresh_token, expiry
+	FROM user_auth
+	WHERE user_id = $1
+	`
+
+	var token oauth2.Token
+	if err := r.QueryRow(ctx, query, id).Scan(&token.AccessToken, &token.TokenType, &token.RefreshToken, &token.Expiry); err != nil {
+		return oauth2.Token{}, err
+	}
+
+	return token, nil
+}
+
+func (r *UserAuthRepository) SetToken(ctx context.Context, id uuid.UUID, token *oauth2.Token) error {
+	fmt.Printf("user id: %s\n", id)
+	const query string = `
+	INSERT INTO user_auth (user_id, access_token, token_type, refresh_token, expiry)
+	VALUES ($1, $2, $3, $4, $5)
+	ON CONFLICT ON CONSTRAINT user_auth_user_id_unique
+	DO UPDATE SET 
+		access_token = $2, 
+		token_type = $3, 
+		refresh_token = $4, 
+		expiry = $5
+	`
+
+	if _, err := r.Exec(ctx, query, id, token.AccessToken, token.TokenType, token.RefreshToken, token.Expiry); err != nil {
+		fmt.Printf("error: %v\n", err)
+		return err
+	}
+
+	return nil
+}
+
+func NewUserAuthRepository(db *pgxpool.Pool) *UserAuthRepository {
+	return &UserAuthRepository{
+		db,
+	}
+}

--- a/backend/internal/storage/postgres/schema/user_auth.go
+++ b/backend/internal/storage/postgres/schema/user_auth.go
@@ -2,47 +2,35 @@ package schema
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"golang.org/x/oauth2"
 )
 
 type UserAuthRepository struct {
 	*pgxpool.Pool
 }
 
-func (r *UserAuthRepository) GetToken(ctx context.Context, id uuid.UUID) (oauth2.Token, error) {
-	const query string = `
-	SELECT access_token, token_type, refresh_token, expiry
-	FROM user_auth
-	WHERE user_id = $1
-	`
+func (r *UserAuthRepository) GetToken(ctx context.Context, id uuid.UUID) (string, error) {
+	const query string = `SELECT token FROM user_auth WHERE user_id = $1`
 
-	var token oauth2.Token
-	if err := r.QueryRow(ctx, query, id).Scan(&token.AccessToken, &token.TokenType, &token.RefreshToken, &token.Expiry); err != nil {
-		return oauth2.Token{}, err
+	var token string
+	if err := r.QueryRow(ctx, query, id).Scan(&token); err != nil {
+		return "", err
 	}
 
 	return token, nil
 }
 
-func (r *UserAuthRepository) SetToken(ctx context.Context, id uuid.UUID, token *oauth2.Token) error {
-	fmt.Printf("user id: %s\n", id)
+func (r *UserAuthRepository) SetToken(ctx context.Context, id uuid.UUID, token string) error {
 	const query string = `
-	INSERT INTO user_auth (user_id, access_token, token_type, refresh_token, expiry)
-	VALUES ($1, $2, $3, $4, $5)
+	INSERT INTO user_auth (user_id, token)
+	VALUES ($1, $2)
 	ON CONFLICT ON CONSTRAINT user_auth_user_id_unique
-	DO UPDATE SET 
-		access_token = $2, 
-		token_type = $3, 
-		refresh_token = $4, 
-		expiry = $5
+	DO UPDATE SET token = $2 
 	`
 
-	if _, err := r.Exec(ctx, query, id, token.AccessToken, token.TokenType, token.RefreshToken, token.Expiry); err != nil {
-		fmt.Printf("error: %v\n", err)
+	if _, err := r.Exec(ctx, query, id, token); err != nil {
 		return err
 	}
 

--- a/backend/internal/storage/postgres/storage.go
+++ b/backend/internal/storage/postgres/storage.go
@@ -12,7 +12,8 @@ import (
 )
 
 func ConnectDatabase(config config.DB) *pgxpool.Pool {
-	dbConfig, err := pgxpool.ParseConfig(config.Connection())
+	dbConfig, err := pgxpool.ParseConfig("postgresql://postgres:postgres@127.0.0.1:54322/postgres")
+	// dbConfig, err := pgxpool.ParseConfig(config.Connection())
 	if err != nil {
 		log.Fatal("Failed to create a config, error: ", err)
 	}
@@ -45,5 +46,6 @@ func NewRepository(config config.DB) *storage.Repository {
 		UserReviewVote: schema.NewVoteRepository(db),
 		Media:          schema.NewMediaRepository(db),
 		Recommendation: schema.NewRecommendationRepository(db),
+		UserAuth:       schema.NewUserAuthRepository(db),
 	}
 }

--- a/backend/internal/storage/postgres/storage.go
+++ b/backend/internal/storage/postgres/storage.go
@@ -12,8 +12,7 @@ import (
 )
 
 func ConnectDatabase(config config.DB) *pgxpool.Pool {
-	dbConfig, err := pgxpool.ParseConfig("postgresql://postgres:postgres@127.0.0.1:54322/postgres")
-	// dbConfig, err := pgxpool.ParseConfig(config.Connection())
+	dbConfig, err := pgxpool.ParseConfig(config.Connection())
 	if err != nil {
 		log.Fatal("Failed to create a config, error: ", err)
 	}

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -5,7 +5,6 @@ import (
 	"platnm/internal/models"
 
 	"github.com/google/uuid"
-	"golang.org/x/oauth2"
 )
 
 type UserRepository interface {
@@ -57,8 +56,8 @@ type VoteRepository interface {
 }
 
 type UserAuthRepository interface {
-	GetToken(ctx context.Context, id uuid.UUID) (oauth2.Token, error)
-	SetToken(ctx context.Context, id uuid.UUID, token *oauth2.Token) error
+	GetToken(ctx context.Context, id uuid.UUID) (string, error)
+	SetToken(ctx context.Context, id uuid.UUID, token string) error
 }
 
 // Repository storage of all repositories.

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -5,6 +5,7 @@ import (
 	"platnm/internal/models"
 
 	"github.com/google/uuid"
+	"golang.org/x/oauth2"
 )
 
 type UserRepository interface {
@@ -44,7 +45,7 @@ type MediaRepository interface {
 type RecommendationRepository interface {
 	CreateRecommendation(ctx context.Context, recommendation *models.Recommendation) (*models.Recommendation, error)
 	GetRecommendation(ctx context.Context, id string) (*models.Recommendation, error)
-	UpdateRecommendation(ctx context.Context, recommendation *models.Recommendation) (error)
+	UpdateRecommendation(ctx context.Context, recommendation *models.Recommendation) error
 	GetRecommendations(ctx context.Context, id string) ([]*models.Recommendation, error)
 }
 
@@ -55,6 +56,11 @@ type VoteRepository interface {
 	DeleteVote(ctx context.Context, userID string, reviewID string) error
 }
 
+type UserAuthRepository interface {
+	GetToken(ctx context.Context, id uuid.UUID) (oauth2.Token, error)
+	SetToken(ctx context.Context, id uuid.UUID, token *oauth2.Token) error
+}
+
 // Repository storage of all repositories.
 type Repository struct {
 	User           UserRepository
@@ -62,4 +68,5 @@ type Repository struct {
 	UserReviewVote VoteRepository
 	Media          MediaRepository
 	Recommendation RecommendationRepository
+	UserAuth       UserAuthRepository
 }

--- a/backend/internal/supabase/migrations/20241026004017_add-expiry-user-auth.sql
+++ b/backend/internal/supabase/migrations/20241026004017_add-expiry-user-auth.sql
@@ -1,0 +1,8 @@
+ALTER TABLE user_auth 
+ADD COLUMN expiry TIMESTAMP;
+
+ALTER TABLE user_auth
+ADD COLUMN token_type TEXT;
+
+ALTER TABLE user_auth
+ADD CONSTRAINT user_auth_user_id_unique UNIQUE (user_id);

--- a/backend/internal/supabase/migrations/20241026004017_add-expiry-user-auth.sql
+++ b/backend/internal/supabase/migrations/20241026004017_add-expiry-user-auth.sql
@@ -1,8 +1,5 @@
-ALTER TABLE user_auth 
-ADD COLUMN expiry TIMESTAMP;
-
 ALTER TABLE user_auth
-ADD COLUMN token_type TEXT;
-
-ALTER TABLE user_auth
-ADD CONSTRAINT user_auth_user_id_unique UNIQUE (user_id);
+    DROP COLUMN refresh_token,
+    DROP COLUMN access_token,
+    ADD COLUMN token text,
+    ADD CONSTRAINT user_auth_user_id_unique UNIQUE (user_id);

--- a/backend/internal/supabase/seed.sql
+++ b/backend/internal/supabase/seed.sql
@@ -74,14 +74,6 @@ VALUES
   (2, 2),
   (3, 3);
 
-INSERT INTO user_auth (id, user_id, refresh_token, access_token)
-VALUES
-  (1, '1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 'refresh_token_abc123', 'access_token_xyz123'),
-  (2, '2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e', 'refresh_token_def456', 'access_token_uvw456'),
-  (3, '3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f', 'refresh_token_ghi789', 'access_token_rst789'),
-  (4, '4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9d', 'refresh_token_jkl012', 'access_token_opq012'),
-  (5, '5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9d0e', 'refresh_token_mno345', 'access_token_lmn345');
-
 INSERT INTO user_review_vote (user_id, review_id, upvote)
 VALUES
   ('1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d', 1, true),


### PR DESCRIPTION
The goal of this PR is to create middleware for setting up user-authenticated http clients for the spotify api. now if a route needs to make a user authenticated request to spotify, they need to include the WithAuthenticatedSpotifyClient middleware, and then retrieve the client from the fiber context using ctxt.GetAuthenticatedSpotifyClient(c)

attached is a screenshot of getting my private playlists. i went through the oauth begin and callback routes so my token would be stored in the database. then i hit the GET /spotify/:userID/playlists route (which is a dummy route for testing authenticated calls)

also, i added token encryption/decryption so refresh/access tokens are not stored in plaintext, and they can be retrieved and used from the database

## Description
<!--- Describe your changes in detail -->
[Link to Ticket](insert the link to your ticket inside the parenthesis here)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Some tests are included that test my code

## Screenshots:
<img width="1440" alt="Screenshot 2024-10-28 at 8 00 46 PM" src="https://github.com/user-attachments/assets/0071525c-de39-46c8-a7d5-3b24657900c4">

