### PR TITLE
Get User's Top Items

### DIFF
--- a/backend/internal/service/handler/oauth/spotify/handler.go
+++ b/backend/internal/service/handler/oauth/spotify/handler.go
@@ -17,7 +17,12 @@ type Handler struct {
 func NewHandler(store *session.SessionStore, config config.Spotify, userAuthRepository storage.UserAuthRepository) *Handler {
 	authenticator := spotifyauth.New(
 		spotifyauth.WithRedirectURL(config.RedirectURI),
-		spotifyauth.WithScopes(spotifyauth.ScopeUserReadPrivate, spotifyauth.ScopePlaylistReadPrivate, spotifyauth.ScopePlaylistReadCollaborative),
+		spotifyauth.WithScopes(
+			spotifyauth.ScopeUserReadPrivate,
+			spotifyauth.ScopePlaylistReadPrivate,
+			spotifyauth.ScopePlaylistReadCollaborative,
+			spotifyauth.ScopeUserTopRead,
+		),
 		spotifyauth.WithClientID(config.ClientID),
 		spotifyauth.WithClientSecret(config.ClientSecret),
 	)

--- a/backend/internal/service/handler/spotify/get_top_items.go
+++ b/backend/internal/service/handler/spotify/get_top_items.go
@@ -1,0 +1,29 @@
+package spotify
+
+import (
+	"platnm/internal/service/ctxt"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func (h *SpotifyHandler) GetTopItems(c *fiber.Ctx) error {
+	client, err := ctxt.GetSpotifyClient(c)
+	if err != nil {
+		return err
+	}
+
+	topTracks, err := client.CurrentUsersTopTracks(c.Context())
+	if err != nil {
+		return err
+	}
+
+	topArtists, err := client.CurrentUsersTopArtists(c.Context())
+	if err != nil {
+		return err
+	}
+
+	return c.Status(fiber.StatusOK).JSON(fiber.Map{
+		"topTracks":  topTracks.Tracks,
+		"topArtists": topArtists.Artists,
+	})
+}

--- a/backend/internal/service/middleware/spotify/spotify.go
+++ b/backend/internal/service/middleware/spotify/spotify.go
@@ -35,29 +35,31 @@ func NewMiddleware(config config.Spotify, userAuthRepository storage.UserAuthRep
 
 func (m *Middleware) WithAuthenticatedSpotifyClient() fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		client, err := m.sessionStore.GetAuthSpotifyClient(c)
+		token, err := m.sessionStore.GetAuthToken(c)
 		if err != nil {
 			return err
 		}
 
-		if client != nil {
-			ctxt.SetSpotifyClient(c, client)
-			return c.Next()
-		}
+		if token == nil {
+			uid, err := uuid.Parse(c.Params("userID"))
+			if err != nil {
+				return err
+			}
 
-		uid, err := uuid.Parse(c.Params("userID"))
-		if err != nil {
-			return err
-		}
+			encryptedToken, err := m.userAuthRepository.GetToken(c.Context(), uid)
+			if err != nil {
+				return err
+			}
 
-		encryptedToken, err := m.userAuthRepository.GetToken(c.Context(), uid)
-		if err != nil {
-			return err
-		}
+			t, err := oauth.DecryptToken(encryptedToken)
+			token = &t
+			if err != nil {
+				return err
+			}
 
-		token, err := oauth.DecryptToken(encryptedToken)
-		if err != nil {
-			return err
+			if err := m.sessionStore.SetAuthToken(c, token); err != nil {
+				return err
+			}
 		}
 
 		// client id and secret are required to refresh the token
@@ -65,12 +67,8 @@ func (m *Middleware) WithAuthenticatedSpotifyClient() fiber.Handler {
 			spotifyauth.WithClientID(m.clientID),
 			spotifyauth.WithClientSecret(m.clientSecret),
 		)
-		httpClient := authenticator.Client(c.Context(), &token)
-		client = spotify.New(httpClient)
-
-		if err := m.sessionStore.SetAuthSpotifyClient(c, client); err != nil {
-			return err
-		}
+		httpClient := authenticator.Client(c.Context(), token)
+		client := spotify.New(httpClient)
 
 		ctxt.SetSpotifyClient(c, client)
 		return c.Next()
@@ -79,33 +77,30 @@ func (m *Middleware) WithAuthenticatedSpotifyClient() fiber.Handler {
 
 func (m *Middleware) WithSpotifyClient() fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		client, err := m.sessionStore.GetClientCredsSpotifyClient(c)
+		token, err := m.sessionStore.GetClientCredsToken(c)
 		if err != nil {
 			return err
 		}
 
-		if client != nil {
-			ctxt.SetSpotifyClient(c, client)
-			return c.Next()
-		}
+		if token == nil {
+			config := &clientcredentials.Config{
+				ClientID:     m.clientID,
+				ClientSecret: m.clientSecret,
+				TokenURL:     spotifyauth.TokenURL,
+			}
 
-		config := &clientcredentials.Config{
-			ClientID:     m.clientID,
-			ClientSecret: m.clientSecret,
-			TokenURL:     spotifyauth.TokenURL,
-		}
+			token, err = config.Token(c.Context())
+			if err != nil {
+				return err
+			}
 
-		token, err := config.Token(c.Context())
-		if err != nil {
-			return err
+			if err := m.sessionStore.SetClientCredsToken(c, token); err != nil {
+				return err
+			}
 		}
 
 		httpClient := spotifyauth.Authenticator{}.Client(c.Context(), token)
-		client = spotify.New(httpClient)
-
-		if err := m.sessionStore.SetClientCredsSpotifyClient(c, client); err != nil {
-			return err
-		}
+		client := spotify.New(httpClient)
 
 		ctxt.SetSpotifyClient(c, client)
 		return c.Next()

--- a/backend/internal/service/server.go
+++ b/backend/internal/service/server.go
@@ -119,6 +119,7 @@ func setupRoutes(app *fiber.App, config config.Config) {
 		r.Route("/:userID", func(authRoute fiber.Router) {
 			authRoute.Use(m.WithAuthenticatedSpotifyClient())
 			authRoute.Get("/playlists", h.GetCurrentUserPlaylists)
+			authRoute.Get("/top-items", h.GetTopItems)
 		})
 
 		r.Route("/", func(clientCredRoute fiber.Router) {

--- a/backend/internal/service/session/session.go
+++ b/backend/internal/service/session/session.go
@@ -2,7 +2,7 @@ package session
 
 import (
 	"github.com/gofiber/fiber/v2/middleware/session"
-	"github.com/zmb3/spotify/v2"
+	"golang.org/x/oauth2"
 )
 
 type SessionStore struct {
@@ -15,7 +15,7 @@ func NewSessionStore(config session.Config) *SessionStore {
 	}
 
 	store.RegisterType(UserState{})
-	store.RegisterType(spotify.Client{})
+	store.RegisterType(oauth2.Token{})
 
 	return store
 }

--- a/backend/internal/service/session/spotify.go
+++ b/backend/internal/service/session/spotify.go
@@ -2,64 +2,64 @@ package session
 
 import (
 	"github.com/gofiber/fiber/v2"
-	"github.com/zmb3/spotify/v2"
+	"golang.org/x/oauth2"
 )
 
 const (
-	authSpotifyClientKey        = "authSpotifyClient"
-	clientCredsSpotifyClientKey = "clientCredsSpotifyClient"
+	authTokenKey        = "authToken"
+	clientCredsTokenKey = "clientCredsToken"
 )
 
-func (u *SessionStore) SetAuthSpotifyClient(c *fiber.Ctx, client *spotify.Client) error {
+func (u *SessionStore) SetAuthToken(c *fiber.Ctx, token *oauth2.Token) error {
 	sess, err := u.Get(c)
 	if err != nil {
 		return err
 	}
 
-	sess.Set(authSpotifyClientKey, client)
+	sess.Set(authTokenKey, token)
 	if err := sess.Save(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (u *SessionStore) GetAuthSpotifyClient(c *fiber.Ctx) (*spotify.Client, error) {
+func (u *SessionStore) GetAuthToken(c *fiber.Ctx) (*oauth2.Token, error) {
 	sess, err := u.Get(c)
 	if err != nil {
 		return nil, err
 	}
 
-	v := sess.Get(authSpotifyClientKey)
+	v := sess.Get(authTokenKey)
 	if v == nil {
 		return nil, nil
 	}
 
-	return v.(*spotify.Client), nil
+	return v.(*oauth2.Token), nil
 }
 
-func (u *SessionStore) SetClientCredsSpotifyClient(c *fiber.Ctx, client *spotify.Client) error {
+func (u *SessionStore) SetClientCredsToken(c *fiber.Ctx, token *oauth2.Token) error {
 	sess, err := u.Get(c)
 	if err != nil {
 		return err
 	}
 
-	sess.Set(clientCredsSpotifyClientKey, client)
+	sess.Set(clientCredsTokenKey, token)
 	if err := sess.Save(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (u *SessionStore) GetClientCredsSpotifyClient(c *fiber.Ctx) (*spotify.Client, error) {
+func (u *SessionStore) GetClientCredsToken(c *fiber.Ctx) (*oauth2.Token, error) {
 	sess, err := u.Get(c)
 	if err != nil {
 		return nil, err
 	}
 
-	v := sess.Get(clientCredsSpotifyClientKey)
+	v := sess.Get(clientCredsTokenKey)
 	if v == nil {
 		return nil, nil
 	}
 
-	return v.(*spotify.Client), nil
+	return v.(*oauth2.Token), nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Made a route for /spotify/user/:id path. Used zmb3 Go wrapper to get current top artists and tracks from Spotify using user credentials, however the current handler/middleware does not retrieve user access tokens from user_auth table yet. 

@aaronkim218 made great changes to the user auth flow and made this ticket work. He added a 'spotify_middleware' that allows for users to login and then their access tokens persist within context, allowing my code to be unchanged, other than moving my endpoint into his route with his handler. **Note:** my endpoint is now .../spotify/:userID/top-items, since it is under the .../spotify/:userID route. 

Also with Aarons, help I added pagination to the requests, with optional query parameters page and limit. Default values will be assigned if the parameters are invalid or missing, of 1 for page and 10 for limit. Note that even with 1 for both parameters, the response for my account is 1168 lines.

The flow to test this endpoint is: 
- Run backend
- If on browser, hit localhost:8080/auth/spotify/begin/:userID with any userID that will be attributed with the account info in the user_auth table. A Spotify login will be prompted, with options for SSO if used.
- optional query parameters can be appended .../:userID?page=1&limit=3
- Use Postman to hit localhost:8080/spotify/:userID/top-items with the same userID as before.

**Note:** in order to use browser for testing, line 47 in .../utils/server.go must be commented out.

	sessionStore := platnm_session.NewSessionStore(session.Config{
		Storage:    memory.New(),
		Expiration: constants.SessionDuration,
		// KeyLookup:  "header:" + constants.HeaderSession, (line 47)
	})

Also, hitting the endpoint multiple times within the same browser for different userIDs will just return 'Found' instead of prompting for sign-in, because the cookie saves the relevant access token (I believe this is the reason). To force the Spotify prompt, use incognito or wipe cookies. 

## Description
<!--- Describe your changes in detail -->
[Link to Ticket](https://github.com/GenerateNU/platnm/issues/83)

## How Has This Been Tested?
Used my own credentials and received valid body, with valid query parameters, invalid parameters, and no parameters.

Used an invalid and received a 500 status error. (This will have to be improved but the erroring from this is inconsistent right now. A user-id that is an invalid length will receive an "ERROR HTTP API error err="invalid UUID length: 7"" error, a valid-format but unrecognized one will receive different errors based on context. "ERROR HTTP API error err="no rows in result set" method=GET" is a common one, but if the request is made directly after a successful request, then regardless of the userId passed in the path, an error "ERROR HTTP API error err="interface conversion: interface {} is oauth2.Token, not *oauth2.Token"" is thrown, even if the uuid is invalid length).

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Some tests are included that test my code

## Screenshots:
![image](https://github.com/user-attachments/assets/2ea0a214-fc7e-42c3-92f4-d13f66450611)
![image](https://github.com/user-attachments/assets/b1bf23b2-bbc7-442b-bd09-a2d145fe2d29)
![image](https://github.com/user-attachments/assets/0d0f6e9d-8049-4430-97a8-67d2dd1eaf1b)
![image](https://github.com/user-attachments/assets/8ca54c05-10bc-4dd6-8362-da2b45362f89)