### PR TITLE
Enhance media endpoint

### DIFF
--- a/backend/internal/models/media.go
+++ b/backend/internal/models/media.go
@@ -34,6 +34,7 @@ type Album struct {
 	Cover       string    `json:"cover"`
 	Country     string    `json:"country"`
 	GenreID     int       `json:"genre_id"`
+	ArtistName  string    `json:"artist_name"`
 }
 
 type Track struct {
@@ -45,6 +46,7 @@ type Track struct {
 	Title       string    `json:"title"`
 	Duration    int       `json:"duration_seconds"`
 	ReleaseDate time.Time `json:"release_date"`
+	ArtistName  string    `json:"artist_name"`
 	Cover       string    `json:"cover"`
 }
 

--- a/backend/internal/service/handler/media/get_media.go
+++ b/backend/internal/service/handler/media/get_media.go
@@ -29,7 +29,8 @@ func (h *Handler) GetMediaByName(c *fiber.Ctx) error {
 func (h *Handler) GetMedia(c *fiber.Ctx) error {
 	type request struct {
 		utils.Pagination
-		Sort string `query:"sort"`
+		Sort      string `query:"sort"`
+		MediaType string `query:"type"`
 	}
 
 	var req request
@@ -50,7 +51,7 @@ func (h *Handler) GetMedia(c *fiber.Ctx) error {
 
 		return c.Status(fiber.StatusOK).JSON(media)
 	case "reviews":
-		media, err := h.mediaRepository.GetMediaByReviews(c.Context(), req.Limit, req.GetOffset())
+		media, err := h.mediaRepository.GetMediaByReviews(c.Context(), req.Limit, req.GetOffset(), &req.MediaType)
 		if err != nil {
 			return err
 		}
@@ -58,7 +59,7 @@ func (h *Handler) GetMedia(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusOK).JSON(media)
 	default:
 		// if no sort query parameter is provided, default to some arbitrary sorting order
-		media, err := h.mediaRepository.GetMediaByReviews(c.Context(), req.Limit, req.GetOffset())
+		media, err := h.mediaRepository.GetMediaByReviews(c.Context(), req.Limit, req.GetOffset(), &req.MediaType)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/storage/postgres/schema/media.go
+++ b/backend/internal/storage/postgres/schema/media.go
@@ -322,52 +322,64 @@ func (r *MediaRepository) GetMediaByReviews(ctx context.Context, limit, offset i
 	// if the column is null, the pointer will be nil
 	// fields need to be exported so pgx can access them via reflection
 	type columns struct {
-		MediaType   string `db:"media_type"`
-		ReviewCount int    `db:"review_count"`
+		MediaType   string     `db:"media_type"`
+		MediaId     int        `db:"media_id"`
+		ReviewCount int        `db:"review_count"`
+		Title       string     `db:"title"`
+		ArtistName  string     `db:"artist_name"`
+		Cover       *string    `db:"cover"`
+		ReleaseDate *time.Time `db:"release_date"`
 
 		// album columns
-		AlbumID     *int       `db:"album_id"`
-		AlbumTitle  *string    `db:"album_title"`
-		ReleaseDate *time.Time `db:"release_date"`
-		Cover       *string    `db:"cover"`
-		Country     *string    `db:"country"`
-		GenreID     *int       `db:"genre_id"`
+		AlbumID *int    `db:"album_id"`
+		Country *string `db:"country"`
+		GenreID *int    `db:"genre_id"`
 
 		// track columns
-		TrackID      *int    `db:"track_id"`
-		TrackTitle   *string `db:"track_title"`
-		TrackAlbumID *int    `db:"track_album_id"`
-		Duration     *int    `db:"duration_seconds"`
+		TrackID      *int `db:"track_id"`
+		TrackAlbumID *int `db:"track_album_id"`
+		Duration     *int `db:"duration_seconds"`
 	}
 
 	const query string = `
-	WITH MostReviewed AS (
-		SELECT media_id, media_type, COUNT(*) AS review_count
-		FROM review
-		GROUP BY media_id, media_type
-		ORDER BY review_count DESC
-		LIMIT $1 OFFSET $2
-	)
-	SELECT 
-		m.media_type,
-		m.review_count,
-		a.id AS album_id,
-		a.title AS album_title,
-		a.release_date,
-		a.cover as cover,
-		a.country,
-		a.genre_id,
-		t.id AS track_id,
-		t.title AS track_title,
-		t.album_id AS track_album_id,
-		t.duration_seconds
-	FROM MostReviewed m
-	LEFT JOIN track t ON m.media_id = t.id AND m.media_type = 'track'
-	JOIN album a ON (t.album_id = a.id OR (m.media_id = a.id AND m.media_type = 'album'))
-	ORDER BY m.review_count DESC;
+		WITH MostReviewed AS (
+				SELECT media_id, media_type, COUNT(*) AS review_count
+				FROM review
+				GROUP BY media_id, media_type
+				ORDER BY review_count DESC
+				LIMIT $1 OFFSET $2
+			)
+			SELECT 
+				m.media_type,
+				m.media_id,
+				m.review_count,
+				COALESCE(a.title, t.title) AS title, 
+				COALESCE(a.artists, t.artists) AS artist_name
+				COALESCE(a.cover, t.cover) AS media_cover, 
+				COALESCE(a.release_date, t.release_date) AS release_date, 
+				t.album_id AS track_album_id,
+				t.duration_seconds,
+			FROM MostReviewed m
+		LEFT JOIN (
+			SELECT t.title, t.id, STRING_AGG(ar.name, ', ') AS artists, cover, album_id, duration_seconds, release_date
+				FROM track t
+			LEFT JOIN track_artist ta on t.id = ta.track_id
+				JOIN artist ar ON ta.artist_id = ar.id
+			JOIN album a on t.album_id = a.id
+				GROUP BY t.id, cover, t.title, album_id, duration_seconds, release_date
+			) t ON m.media_type = 'track' AND m.media_id = t.id
+		LEFT JOIN (
+			SELECT a.id, a.title, STRING_AGG(ar.name, ', ') AS artists, cover, release_date
+				FROM album a
+				LEFT JOIN album_artist aa on a.id = aa.album_id
+				JOIN artist ar ON aa.artist_id = ar.id
+				GROUP BY a.id, cover, a.title
+		) a ON (m.media_type = 'album' AND m.media_id = a.id)
+		WHERE ($3 IS NULL OR (m.media_type = $3))
+		ORDER BY m.review_count DESC;
 	`
-
-	rows, err := r.Query(ctx, query, limit, offset)
+	mediaFilter := "track"
+	rows, err := r.Query(ctx, query, limit, offset, mediaFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -384,22 +396,22 @@ func (r *MediaRepository) GetMediaByReviews(ctx context.Context, limit, offset i
 			album := &models.Album{
 				MediaType:   models.AlbumMedia,
 				ID:          *c.AlbumID,
-				Title:       *c.AlbumTitle,
+				Title:       c.Title,
 				ReleaseDate: *c.ReleaseDate,
 				Cover:       *c.Cover,
-				Country:     *c.Country,
-				GenreID:     *c.GenreID,
+				ArtistName:  c.ArtistName,
 			}
 
 			media = album
 		case string(models.TrackMedia):
 			track := &models.Track{
-				MediaType: models.TrackMedia,
-				ID:        *c.TrackID,
-				AlbumID:   *c.TrackAlbumID,
-				Title:     *c.TrackTitle,
-				Duration:  *c.Duration,
-				Cover:     *c.Cover,
+				MediaType:  models.TrackMedia,
+				ID:         *c.TrackID,
+				Title:      c.Title,
+				AlbumID:    *c.TrackAlbumID,
+				Duration:   *c.Duration,
+				Cover:      *c.Cover,
+				ArtistName: c.ArtistName,
 			}
 
 			media = track

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -35,7 +35,7 @@ type ReviewRepository interface {
 type MediaRepository interface {
 	GetMediaByName(ctx context.Context, name string, mediaType models.MediaType) ([]models.Media, error)
 	GetMediaByDate(ctx context.Context) ([]models.Media, error)
-	GetMediaByReviews(ctx context.Context, limit, offset int) ([]models.MediaWithReviewCount, error)
+	GetMediaByReviews(ctx context.Context, limit, offset int, mediaType *string) ([]models.MediaWithReviewCount, error)
 	GetExistingArtistBySpotifyID(ctx context.Context, id string) (*int, error)
 	AddArtist(ctx context.Context, artist *models.Artist) (*models.Artist, error)
 	GetExistingAlbumBySpotifyID(ctx context.Context, id string) (*int, error)


### PR DESCRIPTION
This PR enhances the GetMedia endpoint so that it takes in a filter for album/track (which can also be left out), and so that it returns artist name with the response data. 

no media_type filter (contains both tracks and albums)
<img width="834" alt="image" src="https://github.com/user-attachments/assets/371d26e3-9064-4cef-8732-c6f9f61efb37">

filtered by tracks (only tracks)
<img width="633" alt="image" src="https://github.com/user-attachments/assets/bc194b9c-f992-4a3a-9967-95b813b6e066">

filtered by albums (only albums)
<img width="673" alt="image" src="https://github.com/user-attachments/assets/d39e8624-4559-48ff-88a1-d6a9b55c39fe">


