### PR TITLE
Histogram data & featurethon fixes

### DIFF
--- a/frontend/app/MediaPage.tsx
+++ b/frontend/app/MediaPage.tsx
@@ -25,6 +25,7 @@ export default function MediaPage() {
   const [media, setMedia] = useState<Media>();
   const [reviews, setReviews] = useState<Review[]>([]);
   const [rating, setReviewAvgRating] = useState<number | null>(null);
+  const [ratingDistributions, setRatingDistributions] = useState<RatingDistribution[]>([]);
 
   const BASE_URL = process.env.EXPO_PUBLIC_BASE_URL;
   const navigation = useNavigation<NativeStackNavigationProp<any>>();
@@ -41,6 +42,29 @@ export default function MediaPage() {
       .then((response) => setMedia(response.data))
       .catch((error) => console.error(error));
   }, []);
+
+  // calculating the rating distribution from the reviews that we already have 
+  useEffect(() => {
+    const calculateRatingDistribution = () => {
+      const distributionMap = new Map<number, number>();
+
+      reviews.forEach(review => {
+        distributionMap.set(
+          review.rating,
+          (distributionMap.get(review.rating) || 0) + 1
+        );
+      });
+
+      const distributionArray = Array.from(distributionMap, ([rating, count]) => ({
+        rating,
+        count,
+      })).sort((a, b) => a.rating - b.rating);
+
+      setRatingDistributions(distributionArray);
+    };
+
+    calculateRatingDistribution();
+  }, [reviews]);
 
   useFocusEffect(
     useCallback(() => {
@@ -95,7 +119,7 @@ export default function MediaPage() {
           <View style={styles.titleContainer}>
             {rating && <ReviewStats rating={rating} reviews={reviews} />}
           </View>
-          <Histogram />
+          <Histogram distribution={ratingDistributions}/>
           <View style={styles.socialContainer}>
             <YourRatings count={3} />
             <FriendRatings count={5} />

--- a/frontend/app/MediaPage.tsx
+++ b/frontend/app/MediaPage.tsx
@@ -25,7 +25,9 @@ export default function MediaPage() {
   const [media, setMedia] = useState<Media>();
   const [reviews, setReviews] = useState<Review[]>([]);
   const [rating, setReviewAvgRating] = useState<number | null>(null);
-  const [ratingDistributions, setRatingDistributions] = useState<RatingDistribution[]>([]);
+  const [ratingDistributions, setRatingDistributions] = useState<
+    RatingDistribution[]
+  >([]);
 
   const BASE_URL = process.env.EXPO_PUBLIC_BASE_URL;
   const navigation = useNavigation<NativeStackNavigationProp<any>>();
@@ -43,22 +45,25 @@ export default function MediaPage() {
       .catch((error) => console.error(error));
   }, []);
 
-  // calculating the rating distribution from the reviews that we already have 
+  // calculating the rating distribution from the reviews that we already have
   useEffect(() => {
     const calculateRatingDistribution = () => {
       const distributionMap = new Map<number, number>();
 
-      reviews.forEach(review => {
+      reviews.forEach((review) => {
         distributionMap.set(
           review.rating,
-          (distributionMap.get(review.rating) || 0) + 1
+          (distributionMap.get(review.rating) || 0) + 1,
         );
       });
 
-      const distributionArray = Array.from(distributionMap, ([rating, count]) => ({
-        rating,
-        count,
-      })).sort((a, b) => a.rating - b.rating);
+      const distributionArray = Array.from(
+        distributionMap,
+        ([rating, count]) => ({
+          rating,
+          count,
+        }),
+      ).sort((a, b) => a.rating - b.rating);
 
       setRatingDistributions(distributionArray);
     };
@@ -119,7 +124,7 @@ export default function MediaPage() {
           <View style={styles.titleContainer}>
             {rating && <ReviewStats rating={rating} reviews={reviews} />}
           </View>
-          <Histogram distribution={ratingDistributions}/>
+          <Histogram distribution={ratingDistributions} />
           <View style={styles.socialContainer}>
             <YourRatings count={3} />
             <FriendRatings count={5} />

--- a/frontend/app/MediaPage.tsx
+++ b/frontend/app/MediaPage.tsx
@@ -130,6 +130,7 @@ export default function MediaPage() {
                 key={review.id}
                 preview={{
                   ...review,
+                  review_id: review.id,
                   created_at: new Date(review.created_at),
                   updated_at: new Date(review.updated_at),
                   media_title: media.title,

--- a/frontend/components/media/Histogram.tsx
+++ b/frontend/components/media/Histogram.tsx
@@ -1,13 +1,11 @@
 import { View, Text, StyleSheet } from "react-native";
 import { VictoryAxis, VictoryBar, VictoryChart } from "victory-native";
 
-// TODO: build backend endpoint to get this data
-const DATA = Array.from({ length: 11 }, (_, i) => ({
-  rating: i,
-  count: 20 + 30 * Math.random(),
-}));
+interface HistogramProps {
+  distribution: RatingDistribution[];
+}
 
-const Histogram = () => {
+const Histogram = ({ distribution }: HistogramProps) => {
   return (
     <View style={styles.container}>
       <Text style={styles.text}>Rating Overview</Text>
@@ -24,7 +22,7 @@ const Histogram = () => {
           tickValues={[0, 10]}
         />
         <VictoryBar
-          data={DATA}
+          data={distribution}
           x="rating"
           y="count"
           barRatio={1}

--- a/frontend/types/types.ts
+++ b/frontend/types/types.ts
@@ -115,3 +115,8 @@ type UserComment = {
   // upvotes: number;
   // downvotes: number;
 };
+
+type RatingDistribution {
+  rating: number;
+  count: number;
+}

--- a/frontend/types/types.ts
+++ b/frontend/types/types.ts
@@ -116,7 +116,7 @@ type UserComment = {
   // downvotes: number;
 };
 
-type RatingDistribution {
+type RatingDistribution = {
   rating: number;
   count: number;
-}
+};


### PR DESCRIPTION
Three changes: 
- Made histogram data be dynamically populated. This is done by iterating through the reviews for a piece of media, which was already being retrieved as part of the MediaPage, and then calculating a distribution from it to populate the histogram.
- A minor fix on the MediaPage
- Fixing the featurethon code for top reviews to actually be correctly ordered.  

## Description
[Link to Ticket](https://github.com/GenerateNU/platnm/issues/127)

## How Has This Been Tested?
See screenshots for the frontend fixes

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Some tests are included that test my code

## Screenshots:
![IMG_7421](https://github.com/user-attachments/assets/d441bec2-abff-4755-92d7-0bc54878441e)
![IMG_7420](https://github.com/user-attachments/assets/29535a15-b8ea-4c76-b321-9dd12453031a)