### PR TITLE
Fix search fr?

### DIFF
--- a/frontend/app/(tabs)/search.tsx
+++ b/frontend/app/(tabs)/search.tsx
@@ -55,8 +55,8 @@ const SearchPage: React.FC = () => {
     try {
       const [songsResponse, albumsResponse, profilesResponse] =
         await Promise.all([
-          axios.get(`${BASE_URL}/media/${query}`),
-          axios.get(`${BASE_URL}/media/${query}`),
+          axios.get(`${BASE_URL}/media/${query}?media_type=track`),
+          axios.get(`${BASE_URL}/media/${query}?media_type=album`),
           axios.get(`${BASE_URL}/users/profile/name/${query}`),
         ]);
 

--- a/frontend/components/media/YourRatings.tsx
+++ b/frontend/components/media/YourRatings.tsx
@@ -46,7 +46,7 @@ const YourRatings = ({ user_id, media_id, media_type }: YourRatingsProps) => {
       }
     >
       <View style={styles.textContainer}>
-        <Text style={styles.text}>You've rated this song</Text>
+        <Text style={styles.text}>You've rated this {media_type}</Text>
         <View style={styles.countBubble}>
           <Text style={styles.countText}>{userReviews?.length ?? 0}x</Text>
         </View>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes an issue where songs were being displayed as albums by passing in the proper query param when fetching both media types. it also fixes the backend Spotify searching logic so that the endpoint doesn't break when looking for only albums or only tracks.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
ran locally

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Some tests are included that test my code

## Screenshots:
<!--- If working on a backend ticket, screenshots or a walkthrough of successful API calls are included. -->
<!--- If working on a frontend ticket, screenshots/recording of new screens or functionality are included. -->
